### PR TITLE
id span in debug only

### DIFF
--- a/SpecsFor.Mvc.Demo/Views/Shared/DisplayTemplates/_Layout.cshtml
+++ b/SpecsFor.Mvc.Demo/Views/Shared/DisplayTemplates/_Layout.cshtml
@@ -1,3 +1,10 @@
 ﻿@using Microsoft.Web.Mvc
 @model dynamic
+@if (HttpContext.Current.IsDebuggingEnabled)
+{ // wrap elements with an id for SpecsFor.MVC testing
 <span id="@Html.IdForModel()">@RenderBody()</span>
+}
+else
+{
+@RenderBody()
+}


### PR DESCRIPTION
I added logic in _Layout.cshtml to wrap the elements in the id span only if <compilation debug=true>
