### PR TITLE
Added the ability to provide an applicationHost.config file for the IIS Express process

### DIFF
--- a/SpecsFor.Mvc/IIS/IISExpressConfigBuilder.cs
+++ b/SpecsFor.Mvc/IIS/IISExpressConfigBuilder.cs
@@ -49,5 +49,28 @@ namespace SpecsFor.Mvc.IIS
 			_action.CleanupPublishedFiles = true;
 			return this;
 		}
+
+        /// <summary>
+        /// Sets the path to an IIS application host configuration file.
+        /// </summary>
+        /// <param name="applicationHostConfigurationFile">The full path to the application host configuration file.</param>
+        /// <returns></returns>
+        /// <remarks>If a full path is not given it is assumed that the configuration file is part of the test project
+        /// and will be found in the test assembly's output folder.</remarks>
+        public IISExpressConfigBuilder ApplicationHostConfigurationFile(string applicationHostConfigurationFile)
+        {
+            var hostConfigPath = Path.GetFullPath(applicationHostConfigurationFile);
+
+            if (File.Exists(hostConfigPath))
+            {
+                _action.ApplicationHostConfigurationFile = applicationHostConfigurationFile;
+            }
+            else
+            {
+                throw new FileNotFoundException("No application host configuration files were found in " + hostConfigPath);
+            }
+
+            return this;
+        }
 	}
 }

--- a/SpecsFor.Mvc/IIS/IISExpressProcess.cs
+++ b/SpecsFor.Mvc/IIS/IISExpressProcess.cs
@@ -1,59 +1,147 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Xml;
 
 namespace SpecsFor.Mvc.IIS
 {
-	internal class IISExpressProcess
-	{
-		private readonly string _pathToSite;
-		private Process _iisProcess;
+    internal class IISExpressProcess
+    {
+        private readonly string _pathToSite;
+        private Process _iisProcess;
+        private readonly string _applicationHostConfigurationFile;
 
-		public int PortNumber { get; private set; }
+        /// <summary>
+        /// The name of the website to configure for this instance of IIS Express.
+        /// </summary>
+        private readonly string _webSiteName;
 
-		public IISExpressProcess(string pathToSite)
-		{
-			_pathToSite = pathToSite;
-		}
+        /// <summary>
+        /// Gets the port number in use by this instance of IIS Express.
+        /// </summary>
+        public int PortNumber { get; private set; }
 
-		public void Start()
-		{
-			PortNumber = (new Random()).Next(20000, 50000);
+        #region Constructors
 
-			var startInfo = new ProcessStartInfo
-			                	{
-			                		ErrorDialog = false,
-			                		CreateNoWindow = true,
-			                		UseShellExecute = false,
-			                		Arguments = string.Format("/path:\"{0}\" /port:{1}", _pathToSite, PortNumber)
-			                	};
+        /// <summary>
+        /// Creates a new instance.
+        /// </summary>
+        /// <param name="pathToSite">The full path to the website to host.</param>
+        public IISExpressProcess(string pathToSite)
+        {
+            _pathToSite = pathToSite;
+        }
 
-			var programfiles = !string.IsNullOrEmpty(startInfo.EnvironmentVariables["programfiles(x86)"])
-			                   	? startInfo.EnvironmentVariables["programfiles(x86)"]
-			                   	: startInfo.EnvironmentVariables["programfiles"];
+        /// <summary>
+        /// Creates a new instance.
+        /// </summary>
+        /// <param name="pathToSite">The full path to the website to host.</param>
+        /// <param name="applicationHostConfigurationFile">The full path to the IIS Express application host configuration file.</param>
+        /// <param name="webSiteName">The name of the site in the application host configuration file to configure for this IIS Express process.</param>
+        public IISExpressProcess(string pathToSite, string applicationHostConfigurationFile, string webSiteName)
+            : this(pathToSite)
+        {
+            _applicationHostConfigurationFile = applicationHostConfigurationFile;
+            _webSiteName = webSiteName;
+        }
 
-			var iisExpress = programfiles + "\\IIS Express\\iisexpress.exe";
+        #endregion Constructors
 
-			if (!File.Exists(iisExpress))
-			{
-				throw new FileNotFoundException(string.Format("Did not find iisexpress.exe at {0}. Ensure that IIS Express is installed to the default location.", iisExpress));
-			}
+        /// <summary>
+        /// Starts an IIS Express process that will host the web application.
+        /// </summary>
+        /// <remarks>
+        /// This method finds an open port to configure the site to use and if an application host configuration file
+        /// is being used it also configures the site specified when this instance was created with the correct port
+        /// and path to the web application.
+        /// </remarks>
+        public void Start()
+        {
+            var startInfo = new ProcessStartInfo
+                                {
+                                    ErrorDialog = false,
+                                    CreateNoWindow = true,
+                                    UseShellExecute = false
+                                };
 
-			startInfo.FileName = iisExpress;
+            // Get an open port number on the local system.
+            using (Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                sock.Bind(new IPEndPoint(IPAddress.Loopback, 0));
 
-			_iisProcess = new Process { StartInfo = startInfo };
-			_iisProcess.Start();
-		}
+                PortNumber = ((IPEndPoint)sock.LocalEndPoint).Port;
+            }
 
-		public void Stop()
-		{
-			if (_iisProcess != null && !_iisProcess.HasExited)
-			{
-				_iisProcess.CloseMainWindow();
-				_iisProcess.Kill();
-				_iisProcess.Dispose();
-				_iisProcess = null;
-			}
-		}
-	}
+            // If a configuration file was not provided use the simple IIS Express command line configuration.
+            if (string.IsNullOrEmpty(_applicationHostConfigurationFile))
+            {
+                startInfo.Arguments = string.Format("/path:\"{0}\" /port:{1}", _pathToSite, PortNumber);
+            }
+            else  // When an IIS Express configuration file is used, configure the sites node with information about the current site being tested.
+            {
+                var xDoc = new XmlDocument();
+
+                // Read the application host configuration file into an XML document.
+                using (var hostConfigReader = new StreamReader(_applicationHostConfigurationFile))
+                {
+                    xDoc.Load(hostConfigReader);
+                }
+
+                // Determine if a site node with the given site name in the config.
+                XmlNode site = xDoc.SelectSingleNode("/configuration/system.applicationHost/sites/site[@name=\"" + _webSiteName + "\"]");
+                
+                if (site != null)
+                {
+                    XmlNode virtualDirectory = site.SelectSingleNode("application/virtualDirectory");
+
+                    if (virtualDirectory != null)
+                    {
+                        virtualDirectory.Attributes["physicalPath"].Value = _pathToSite;
+                    }
+
+                    XmlNode binding = site.SelectSingleNode("bindings/binding");
+
+                    if (binding != null)
+                    {
+                        binding.Attributes["bindingInformation"].Value = string.Format(":{0}:localhost", PortNumber);
+                    }
+                }
+
+                xDoc.SelectSingleNode("/configuration/system.applicationHost/sites").ReplaceChild(site, xDoc.SelectSingleNode("/configuration/system.applicationHost/sites/site[@name=\"" + _webSiteName + "\"]"));
+
+                xDoc.Save(_applicationHostConfigurationFile);
+
+                startInfo.Arguments += string.Format(" /config:\"{0}\"", _applicationHostConfigurationFile);
+            }
+
+            var programfiles = !string.IsNullOrEmpty(startInfo.EnvironmentVariables["programfiles(x86)"])
+                                ? startInfo.EnvironmentVariables["programfiles(x86)"]
+                                : startInfo.EnvironmentVariables["programfiles"];
+
+            var iisExpress = programfiles + "\\IIS Express\\iisexpress.exe";
+
+            if (!File.Exists(iisExpress))
+            {
+                throw new FileNotFoundException(string.Format("Did not find iisexpress.exe at {0}. Ensure that IIS Express is installed to the default location.", iisExpress));
+            }
+
+            startInfo.FileName = iisExpress;
+
+            _iisProcess = new Process { StartInfo = startInfo };
+            _iisProcess.Start();
+        }
+
+        public void Stop()
+        {
+            if (_iisProcess != null && !_iisProcess.HasExited)
+            {
+                _iisProcess.CloseMainWindow();
+                _iisProcess.Kill();
+                _iisProcess.Dispose();
+                _iisProcess = null;
+            }
+        }
+    }
 }

--- a/SpecsFor.Mvc/IIS/IISTestRunnerAction.cs
+++ b/SpecsFor.Mvc/IIS/IISTestRunnerAction.cs
@@ -20,9 +20,17 @@ namespace SpecsFor.Mvc.IIS
 
 		public bool CleanupPublishedFiles { get; set; }
 
+        public string ApplicationHostConfigurationFile { get; set; }
+
+        /// <summary>
+        /// Gets the name of the web application project.
+        /// </summary>
+        /// <remarks>This is used to tie back to the site name to configure when an application configuration file is used.</remarks>
+        public string ProjectName { get; private set; }
+
 		private void StartIISExpress()
 		{
-			_iisExpressProcess = new IISExpressProcess(_publishDir);
+            _iisExpressProcess = new IISExpressProcess(_publishDir, ApplicationHostConfigurationFile, ProjectName);
 			_iisExpressProcess.Start();
 
 			MvcWebApp.BaseUrl = "http://localhost:" + _iisExpressProcess.PortNumber;
@@ -74,6 +82,17 @@ namespace SpecsFor.Mvc.IIS
 		public void Startup()
 		{
 			//TODO: Make sure the config is valid!
+
+            if (ProjectPath.Contains("\\"))
+            {
+                ProjectName = ProjectPath.Substring(ProjectPath.LastIndexOf("\\") + 1);
+            }
+            else
+            {
+                ProjectName = ProjectPath;
+            }
+
+            ProjectName = ProjectName.Replace(".csproj", string.Empty).Replace(".vbproj", string.Empty);
 
 			_publishDir = Path.Combine(Directory.GetCurrentDirectory(), "SpecsForMvc.TestSite");
 			_intermediateDir = Path.Combine(Directory.GetCurrentDirectory(), "SpecsForMvc.TempIntermediateDir");


### PR DESCRIPTION
This is to avoid having to alter the default IIS Express applicationHost.config file for doing such things as enabling other authentication methods.

In my case this allows us to specify an applicationHost.config with settings that mimic our production IIS environment with windows authentication enabled.
