### PR TITLE
wait for field to be visible using standard form/model locator

### DIFF
--- a/SpecsFor.Mvc/FluentForm.cs
+++ b/SpecsFor.Mvc/FluentForm.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using OpenQA.Selenium;
@@ -59,7 +58,15 @@ namespace SpecsFor.Mvc
 
 			WebApp.Pause();
 		}
+        public FluentField<TModel, TProp> WaitForFieldToBeVisible<TProp>(Expression<Func<TModel, TProp>> property, TimeSpan? timeout = null, bool throwOnTimeout = false)
+        {
+            IWebElement element = WebApp.WaitForElementToBeVisible<TModel, TProp>(property, timeout, throwOnTimeout);
+            var field = new FluentField<TModel, TProp>(this, WebApp, property, element);
 
+            _lastField = field.Field;
+
+            return field;
+        }
 		private IWebElement FindSingleForm()
 		{
 			var forms = WebApp.Browser.FindElements(By.TagName("form"));

--- a/SpecsFor.Mvc/MvcWebApp.cs
+++ b/SpecsFor.Mvc/MvcWebApp.cs
@@ -1,18 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using System.Threading;
 using System.Web.Mvc;
 using System.Web.Routing;
-using OpenQA.Selenium;
 using Microsoft.Web.Mvc;
+using OpenQA.Selenium;
 using OpenQA.Selenium.Remote;
 using OpenQA.Selenium.Support.UI;
 using SpecsFor.Mvc.Authentication;
 using SpecsFor.Mvc.Helpers;
-using System.Linq;
-using System.Reflection;
-using System.Globalization;
 
 namespace SpecsFor.Mvc
 {
@@ -215,6 +215,11 @@ namespace SpecsFor.Mvc
 			return ElementConventions.IsFieldInvalid(field);
 		}
 
+        public IWebElement WaitForElementToBeVisible<TModel, TProp>(Expression<Func<TModel, TProp>> property, TimeSpan? timeout = null, bool throwOnTimeout = false) where TModel : class
+        {
+            return this.WaitForElementToBeVisible(ElementConventions.FindEditorElementByExpressionFor(property), timeout, throwOnTimeout);
+        }
+
 		public IWebElement WaitForElementToBeVisible(By selector, TimeSpan? timeout = null, bool throwOnTimeout = false)
 		{
 			timeout = timeout ?? TimeSpan.FromSeconds(10);
@@ -230,8 +235,7 @@ namespace SpecsFor.Mvc
 
 			return null;
 		}
-
-		
+        		
 		public string AllText()
         {
             return Browser.FindElement(By.TagName("body")).Text;


### PR DESCRIPTION
Adding wait for field to be visible using findform for approach. Example:

this.SUT.FindFormFor<UserModel>().WaitForFieldToBeVisible(m => m.Username)