### PR TITLE
working https configuration

### DIFF
--- a/SpecsFor.Mvc/IIS/IISExpressConfigBuilder.cs
+++ b/SpecsFor.Mvc/IIS/IISExpressConfigBuilder.cs
@@ -108,6 +108,13 @@ namespace SpecsFor.Mvc.IIS
 			return this;
 		}
 
+        public IISExpressConfigBuilder UseHttps(bool useHttps)
+        {
+            _action.UseHttps = useHttps;
+
+            return this;
+        }
+
 		public IISExpressConfigBuilder WithTemporaryDirectoryName(string name)
 		{
 			_action.TemporaryDirectoryName = name;

--- a/SpecsFor.Mvc/IIS/IISExpressProcess.cs
+++ b/SpecsFor.Mvc/IIS/IISExpressProcess.cs
@@ -74,8 +74,16 @@ namespace SpecsFor.Mvc.IIS
 									UseShellExecute = false
 								};
 
-			if (PortNumber == null) CaptureAvailablePortNumber();
+            if (PortNumber == null)
+            {
+                if (UseHttps)
+                {
+                    throw new ArgumentException("In order to use https you must specify a port that has already been configured for https.");
+                }
 
+                CaptureAvailablePortNumber();
+            }
+            
 			// If a configuration file was not provided use the simple IIS Express command line configuration.
 			if (string.IsNullOrEmpty(_applicationHostConfigurationFile))
 			{

--- a/SpecsFor.Mvc/IIS/IISExpressProcess.cs
+++ b/SpecsFor.Mvc/IIS/IISExpressProcess.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
@@ -21,6 +22,14 @@ namespace SpecsFor.Mvc.IIS
 		/// Gets the port number in use by this instance of IIS Express.
 		/// </summary>
 		public int? PortNumber { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether [use HTTPS].
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [use HTTPS]; otherwise, <c>false</c>.
+        /// </value>
+        public bool UseHttps { get; set; }
 
 		#region Constructors
 
@@ -70,7 +79,54 @@ namespace SpecsFor.Mvc.IIS
 			// If a configuration file was not provided use the simple IIS Express command line configuration.
 			if (string.IsNullOrEmpty(_applicationHostConfigurationFile))
 			{
-				startInfo.Arguments = string.Format("/path:\"{0}\" /port:{1}", _pathToSite, PortNumber);
+                var xDoc = new XmlDocument();
+                string iisConfigPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + @"\iisexpress\config\applicationhost.config";
+
+				// Read the application host configuration file into an XML document.
+				using (var hostConfigReader = new StreamReader(iisConfigPath))
+				{
+					xDoc.Load(hostConfigReader);
+				}
+
+                XmlNode sites = xDoc.SelectSingleNode("/configuration/system.applicationHost/sites");
+                sites.RemoveAll();
+
+                XmlElement site = xDoc.CreateElement("site");
+                site.SetAttribute("name", _webSiteName);
+                site.SetAttribute("id", "1");
+
+                XmlElement application = xDoc.CreateElement("application");
+                application.SetAttribute("path", "/");
+                application.SetAttribute("applicationPool", "Clr4IntegratedAppPool");
+
+                XmlElement virtualDirectory = xDoc.CreateElement("virtualDirectory");
+                virtualDirectory.SetAttribute("physicalPath", _pathToSite);
+                virtualDirectory.SetAttribute("path", "/");
+                application.AppendChild(virtualDirectory);
+                site.AppendChild(application);
+
+
+                XmlElement bindings = xDoc.CreateElement("bindings");
+                XmlElement binding = xDoc.CreateElement("binding");
+                                
+                if (UseHttps){
+                    binding.SetAttribute("protocol", "https");
+                    binding.SetAttribute("bindingInformation", string.Format("*:{0}:localhost", PortNumber));
+                }
+                else
+                {
+                    binding.SetAttribute("protocol", "http");
+                    binding.SetAttribute("bindingInformation", string.Format(":{0}:localhost", PortNumber));
+                }
+
+                bindings.AppendChild(binding);
+                site.AppendChild(bindings);
+
+                sites.AppendChild(site);
+
+                xDoc.Save("specsFor.config");
+
+                startInfo.Arguments = string.Format(" /config:\"specsFor.config\"", _applicationHostConfigurationFile);
 			}
 			else  // When an IIS Express configuration file is used, configure the sites node with information about the current site being tested.
 			{

--- a/SpecsFor.Mvc/IIS/IISTestRunnerAction.cs
+++ b/SpecsFor.Mvc/IIS/IISTestRunnerAction.cs
@@ -34,6 +34,8 @@ namespace SpecsFor.Mvc.IIS
 
 		public int? PortNumber { get; set; }
 
+        public bool UseHttps { get; set; }
+
 		public string TemporaryDirectoryName { get; set; }
 
         public string OutputPath { get; set; }
@@ -42,9 +44,17 @@ namespace SpecsFor.Mvc.IIS
 		{
 			_iisExpressProcess = new IISExpressProcess(_publishDir, ApplicationHostConfigurationFile, ProjectName);
 			_iisExpressProcess.PortNumber = PortNumber;
+            _iisExpressProcess.UseHttps = UseHttps;
 			_iisExpressProcess.Start();
 
-			MvcWebApp.BaseUrl = "http://localhost:" + _iisExpressProcess.PortNumber;
+            string protocol = "http";
+
+            if (_iisExpressProcess.UseHttps)
+            {
+                protocol = "https";
+            }
+
+			MvcWebApp.BaseUrl = protocol + "://localhost:" + _iisExpressProcess.PortNumber;
 		}
 
 		private void PublishSite(Dictionary<string, string> properties)


### PR DESCRIPTION
For issue #66 

Here's what I have:
IISExpressConfigBuilder/IISTestRunnerAction:
1. add usehttps property/method

IISExpressProcess
1. find applicationhost.config in IIS default directory (username\documents\iisexpress\config\applicationhost.config)
2. load it into a xml doc, empty sites node in doc (leave original file alone)
3. create a new site based on the parameters specified (path to site, port, https, etc.)
4. generate new config file (specsFor.config) in output directory
5. have IIS execute new config file

This is working using http and https with the following caveats:
1. applicationhost.config is located in the standard location (changing this requires a registry hack so probably fairly unlikely)
2. you have to use a port that's already setup with https - this could be mitigated by running iisexpressadmin.exe (http://www.hanselman.com/blog/WorkingWithSSLAtDevelopmentTimeIsEasierWithIISExpress.aspx) but that would edit http.sys which that might be too invasive.

Both caveats are easy enough to mitigate, just wanted to see if I was on the right track.