### PR TITLE
Fix SpecsFor to be compatible with NUnit 3.7.1

### DIFF
--- a/SpecsFor.Tests/SpecsFor.Tests.csproj
+++ b/SpecsFor.Tests/SpecsFor.Tests.csproj
@@ -40,25 +40,9 @@
       <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.core">
-      <HintPath>..\packages\NUnitTestAdapter.1.1\lib\nunit.core.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="nunit.core.interfaces">
-      <HintPath>..\packages\NUnitTestAdapter.1.1\lib\nunit.core.interfaces.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
-    </Reference>
-    <Reference Include="nunit.util">
-      <HintPath>..\packages\NUnitTestAdapter.1.1\lib\nunit.util.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="NUnit.VisualStudio.TestAdapter">
-      <HintPath>..\packages\NUnitTestAdapter.1.1\lib\NUnit.VisualStudio.TestAdapter.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="nunit.framework, Version=3.7.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Should, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/SpecsFor.Tests/packages.config
+++ b/SpecsFor.Tests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
-  <package id="NUnit" version="2.6.3" targetFramework="net45" />
-  <package id="NUnitTestAdapter" version="1.1" targetFramework="net45" />
+  <package id="NUnit" version="3.7.1" targetFramework="net45" />
+  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45" />
   <package id="Should" version="1.1.20" targetFramework="net45" />
   <package id="structuremap" version="4.1.3.394" targetFramework="net45" />
 </packages>

--- a/SpecsFor/Configuration/SpecsForConfiguration.cs
+++ b/SpecsFor/Configuration/SpecsForConfiguration.cs
@@ -16,7 +16,7 @@ namespace SpecsFor.Configuration
 			return;
 		}
 
-		[SetUp]
+		[OneTimeSetUp]
 		public virtual void ApplyConfiguration()
 		{
 			BeforeConfigurationApplied();
@@ -34,7 +34,7 @@ namespace SpecsFor.Configuration
 			return;
 		}
 
-		[TearDown]
+		[OneTimeTearDown]
 		public virtual void RemoveConfiguration()
 		{
 			BeforeConfigurationRemoved();

--- a/SpecsFor/SpecsFor.cs
+++ b/SpecsFor/SpecsFor.cs
@@ -51,7 +51,7 @@ namespace SpecsFor
 	    [UsedImplicitly]
         public MoqAutoMocker<T> Mocker => _engine.Mocker;
 
-	    [TestFixtureSetUp]
+	    [OneTimeSetUp]
 	    public virtual void SetupEachSpec()
 	    {
 	        _engine.Init();
@@ -117,7 +117,7 @@ namespace SpecsFor
         /// be sure to call the base implementation, otherwise your specs will not 
         /// be cleaned up correctly!
         /// </summary>
-		[TestFixtureTearDown]
+		[OneTimeTearDown]
 		public virtual void TearDown()
 		{
 			_engine.TearDown();

--- a/SpecsFor/SpecsFor.csproj
+++ b/SpecsFor/SpecsFor.csproj
@@ -49,9 +49,9 @@
       <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.7.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.7.1\lib\net40\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Should, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/SpecsFor/packages.config
+++ b/SpecsFor/packages.config
@@ -3,7 +3,7 @@
   <package id="ExpectedObjects" version="1.2.3" targetFramework="net40" />
   <package id="JetBrains.Annotations" version="10.0.0" targetFramework="net40" developmentDependency="true" />
   <package id="Moq" version="4.2.1510.2205" targetFramework="net40" />
-  <package id="NUnit" version="2.6.3" targetFramework="net45" />
+  <package id="NUnit" version="3.7.1" targetFramework="net40" />
   <package id="Should" version="1.1.20" targetFramework="net45" />
   <package id="structuremap" version="4.1.3.394" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
i had an issue with SpecsFor in my project when i updated the NUnit to 3.7.1 , the problem is all the test cases are failed due to an error in SpecsFor which was  **cannot find the TestFixture** so i only updated some attributes that have been replaced with new ones since Nunit 3.7.1
https://github.com/nunit/docs/wiki/SetUp-and-TearDown-Changes
