### PR TITLE
Prevent reflection/null ref errors when using inherited types with ShouldLookLike

### DIFF
--- a/SpecsFor.Autofac.Tests/ShouldExtensions/ExpectedObjectExtensionsSpecs.cs
+++ b/SpecsFor.Autofac.Tests/ShouldExtensions/ExpectedObjectExtensionsSpecs.cs
@@ -48,5 +48,11 @@ namespace SpecsFor.Autofac.Tests.ShouldExtensions
 		{
 			Assert.Throws<ExpectedObjects.ComparisonException>(() => SUT.ShouldLookLikePartial(new { ID = 5, Name = "blah" }));
 		}
+
+		[Test]
+		public void then_partial_matching_with_a_nonexistant_property_throws_exception()
+		{
+			Assert.Throws<ExpectedObjects.ComparisonException>(() => SUT.ShouldLookLikePartial(new { NotAProperty = 5 }));
+		}
 	}
 }

--- a/SpecsFor.Autofac.Tests/ShouldExtensions/PartialMatchingWithInheritanceSpecs.cs
+++ b/SpecsFor.Autofac.Tests/ShouldExtensions/PartialMatchingWithInheritanceSpecs.cs
@@ -1,4 +1,6 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
+using Should;
 using Should.Core.Exceptions;
 using SpecsFor.Core.ShouldExtensions;
 
@@ -91,12 +93,13 @@ namespace SpecsFor.Autofac.Tests.ShouldExtensions
 		}
 
 		[Test]
-		public void then_it_should_throw_when_property_to_check_does_not_exist_on_object()
+		public void then_it_should_throw_when_property_to_check_does_not_exist_on_actual_object()
 		{
-			Assert.Throws<AssertionException>(() => SUT.ShouldLookLike(() => new ChildTestObject
+			var exception = Assert.Throws<InvalidOperationException>(() => SUT.ShouldLookLike(() => new ChildTestObject
 			{
 				ChildOnly = 12
 			}));
+			exception.Message.ShouldContain("Unable to find property 'ChildOnly' on actual object");
 		}
 	}
 }

--- a/SpecsFor.Autofac.Tests/ShouldExtensions/PartialMatchingWithInheritanceSpecs.cs
+++ b/SpecsFor.Autofac.Tests/ShouldExtensions/PartialMatchingWithInheritanceSpecs.cs
@@ -1,0 +1,102 @@
+﻿using NUnit.Framework;
+using Should.Core.Exceptions;
+using SpecsFor.Core.ShouldExtensions;
+
+namespace SpecsFor.Autofac.Tests.ShouldExtensions
+{
+	public class PartialMatchingWithInheritanceSpecs : SpecsFor<PartialMatchingWithInheritanceSpecs.TestObject>
+	{
+		#region Test Classes
+		public class BaseTestObject
+		{
+			public virtual int Value { get; set; }
+			public int ParentOnly { get; set; }
+		}
+
+		public class TestObject : BaseTestObject
+		{
+			public override int Value { get; set; }
+			public int SUTOnly { get; set; }
+			public virtual int SUTValue { get; set; }
+		}
+
+		public class ChildTestObject : TestObject
+		{
+			public int ChildOnly { get; set; }
+			public override int SUTValue { get;set; }
+		}
+		#endregion
+
+		protected override void InitializeClassUnderTest()
+		{
+			SUT = new TestObject
+			{
+				Value = 10,
+				SUTOnly = 11,
+				ParentOnly = 12,
+				SUTValue = 13
+			};
+		}
+
+		[Test]
+		public void then_it_should_like_parent_classes_with_matching_values()
+		{
+			Assert.DoesNotThrow(() => SUT.ShouldLookLike(() => new BaseTestObject
+			{
+				Value = 10,
+				ParentOnly = 12
+			}));
+		}
+
+		[Test]
+		public void then_it_should_like_identical_class_with_matching_values()
+		{
+			Assert.DoesNotThrow(() => SUT.ShouldLookLike(() => new TestObject
+			{
+				Value = 10,
+				SUTOnly = 11,
+				ParentOnly = 12,
+				SUTValue = 13
+			}));
+		}
+
+		[Test]
+		public void then_it_should_like_child_classes_with_matching_values()
+		{
+			Assert.DoesNotThrow(() => SUT.ShouldLookLike(() => new ChildTestObject
+			{
+				Value = 10,
+				ParentOnly = 12,
+				SUTValue = 13,
+				SUTOnly = 11
+			}));
+		}
+
+		[Test]
+		public void then_it_should_fail_when_inherited_values_differ()
+		{
+			Assert.Throws<EqualException>(() => SUT.ShouldLookLike(() => new BaseTestObject
+			{
+				Value = 20
+			}));
+		}
+
+		[Test]
+		public void then_it_should_fail_when_parent_values_differ()
+		{
+			Assert.Throws<EqualException>(() => SUT.ShouldLookLike(() => new BaseTestObject
+			{
+				ParentOnly = 20
+			}));
+		}
+
+		[Test]
+		public void then_it_should_throw_when_property_to_check_does_not_exist_on_object()
+		{
+			Assert.Throws<AssertionException>(() => SUT.ShouldLookLike(() => new ChildTestObject
+			{
+				ChildOnly = 12
+			}));
+		}
+	}
+}

--- a/SpecsFor.Core/ShouldExtensions/ShouldLooksLikeExtensions.cs
+++ b/SpecsFor.Core/ShouldExtensions/ShouldLooksLikeExtensions.cs
@@ -95,12 +95,24 @@ namespace SpecsFor.Core.ShouldExtensions
 		private static void ShouldMatch(object actual, MemberInitExpression expression)
 		{
 			var expected = Expression.Lambda<Func<object>>(expression).Compile()();
-			var type = actual.GetType();
+			var expectedType = expected.GetType();
+			var actualType = actual.GetType();
 
 			foreach (var memberBinding in expression.Bindings)
 			{
-				var actualValue = type.GetProperty(memberBinding.Member.Name).GetValue(actual, null);
-				var expectedValue = type.GetProperty(memberBinding.Member.Name).GetValue(expected, null);
+				var actualProperty = actualType.GetProperty(memberBinding.Member.Name);
+				if (actualProperty == null)
+				{
+					Assert.Fail($"Unable to find property '{memberBinding.Member.Name}' on actual object of type {actualType.FullName}");
+				}
+				var actualValue = actualProperty.GetValue(actual, null);
+
+				var expectedProperty = expectedType.GetProperty(memberBinding.Member.Name);
+				if (expectedProperty == null)
+				{
+					Assert.Fail($"Unable to find property '{memberBinding.Member.Name}' on expected object of type {expectedType.FullName}");
+				}
+				var expectedValue = expectedProperty.GetValue(expected, null);
 
 				var bindingAsAnotherExpression = memberBinding as MemberAssignment;
 

--- a/SpecsFor.Core/ShouldExtensions/ShouldLooksLikeExtensions.cs
+++ b/SpecsFor.Core/ShouldExtensions/ShouldLooksLikeExtensions.cs
@@ -103,14 +103,14 @@ namespace SpecsFor.Core.ShouldExtensions
 				var actualProperty = actualType.GetProperty(memberBinding.Member.Name);
 				if (actualProperty == null)
 				{
-					Assert.Fail($"Unable to find property '{memberBinding.Member.Name}' on actual object of type {actualType.FullName}");
+					throw new InvalidOperationException($"Unable to find property '{memberBinding.Member.Name}' on actual object of type {actualType.FullName}");
 				}
 				var actualValue = actualProperty.GetValue(actual, null);
 
 				var expectedProperty = expectedType.GetProperty(memberBinding.Member.Name);
 				if (expectedProperty == null)
 				{
-					Assert.Fail($"Unable to find property '{memberBinding.Member.Name}' on expected object of type {expectedType.FullName}");
+					throw new InvalidOperationException($"Unable to find property '{memberBinding.Member.Name}' on expected object of type {expectedType.FullName}");
 				}
 				var expectedValue = expectedProperty.GetValue(expected, null);
 

--- a/SpecsFor.Core/ShouldExtensions/ShouldLooksLikeExtensions.cs
+++ b/SpecsFor.Core/ShouldExtensions/ShouldLooksLikeExtensions.cs
@@ -106,13 +106,7 @@ namespace SpecsFor.Core.ShouldExtensions
 					throw new InvalidOperationException($"Unable to find property '{memberBinding.Member.Name}' on actual object of type {actualType.FullName}");
 				}
 				var actualValue = actualProperty.GetValue(actual, null);
-
-				var expectedProperty = expectedType.GetProperty(memberBinding.Member.Name);
-				if (expectedProperty == null)
-				{
-					throw new InvalidOperationException($"Unable to find property '{memberBinding.Member.Name}' on expected object of type {expectedType.FullName}");
-				}
-				var expectedValue = expectedProperty.GetValue(expected, null);
+				var expectedValue = expectedType.GetProperty(memberBinding.Member.Name).GetValue(expected, null);
 
 				var bindingAsAnotherExpression = memberBinding as MemberAssignment;
 


### PR DESCRIPTION
This means comparing different levels of an object hierarchy doesn't explode messily. E.g., comparing an EntityFramework proxy to it's actual class.

@MattHoneycutt I wasn't entirely sure which direction you'd prefer this behaviour to go if the types don't match. For my own selfish use-case (comparing an EF-proxied object to the user-facing object), it works best if it's ok to compare a child type with something further up the inheritance chain.

Having said that, I could equally easily argue that type mismatch means objects do not match, irrespective of what properties are set. Let me know if you'd prefer me to switch this to fail more quickly if the exact object types don't match.