### PR TITLE
Compare collection lengths during partial comparison with ShouldLookLike

### DIFF
--- a/SpecsFor.Autofac.Tests/ShouldExtensions/ShouldLookLikeExtensionsSpecs.cs
+++ b/SpecsFor.Autofac.Tests/ShouldExtensions/ShouldLookLikeExtensionsSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 using Should;
 using Should.Core.Exceptions;
@@ -451,6 +452,81 @@ namespace SpecsFor.Autofac.Tests.ShouldExtensions
 					}
 				}
 			}));
+		}
+
+		[Test]
+		public void then_it_fails_if_actual_nested_collection_is_empty()
+		{
+			SUT.NestedArray = new TestObject[0];
+			Assert.Throws<EqualException>(() =>
+			{
+				SUT.ShouldLookLike(() => new TestObject
+				{
+					NestedArray = new[] {new TestObject {  Awesomeness = 10 } }
+				});
+			});
+		}
+
+		[Test]
+		public void then_it_fails_if_actual_nested_collection_contains_more_than_expected_element()
+		{
+			SUT.NestedArray = new[]
+			{
+				new TestObject {Awesomeness = 10},
+				new TestObject {Awesomeness = 11}
+			};
+			Assert.Throws<EqualException>(() =>
+			{
+				SUT.ShouldLookLike(() => new TestObject
+				{
+					NestedArray = new[]
+					{
+						new TestObject {Awesomeness = 10},
+					}
+				});
+			});
+		}
+
+		[Test]
+		public void then_it_fails_if_actual_array_is_empty()
+		{
+			var actual = new TestObject[0];
+			Assert.Throws<EqualException>(() =>
+			{
+				actual.ShouldLookLike(() => new[] {new TestObject {Awesomeness = 10}});
+			});
+		}
+
+		[Test]
+		public void then_it_fails_if_actual_array_contains_more_than_expected_element()
+		{
+			var actual = new[]
+				{
+					new TestObject { Awesomeness = 10 },
+					new TestObject { Awesomeness = 11 }
+				};
+			Assert.Throws<EqualException>(() =>
+			{
+				actual.ShouldLookLike(() => new[] {new TestObject {Awesomeness = 10}});
+			});
+		}
+
+		[Test]
+		public void then_it_passes_if_arrays_are_identical()
+		{
+			var actual = new[]
+			{
+				new TestObject { Awesomeness = 10 },
+				new TestObject { Awesomeness = 11 }
+			};
+			Assert.DoesNotThrow(() =>
+			{
+				actual.ShouldLookLike(() => new[]
+				{
+					new TestObject { Awesomeness = 10 },
+					new TestObject { Awesomeness = 11 }
+				});
+			});
 		}
 
 		[Test]

--- a/SpecsFor.Core/ShouldExtensions/ShouldLooksLikeExtensions.cs
+++ b/SpecsFor.Core/ShouldExtensions/ShouldLooksLikeExtensions.cs
@@ -65,6 +65,7 @@ namespace SpecsFor.Core.ShouldExtensions
 				return;
 			}
 
+			array.Length.ShouldEqual(arrayExpression.Expressions.Count, "Actual collection size differs from expected");
 			for (int i = 0; i < arrayExpression.Expressions.Count; i++)
 			{
 				ShouldMatch(array[i], arrayExpression.Expressions[i] as MemberInitExpression);
@@ -86,6 +87,7 @@ namespace SpecsFor.Core.ShouldExtensions
 				return;
 			}
 
+			array.Length.ShouldEqual(arrayExpression.Initializers.Count, "Actual collection size differs from expected");
 			for (int i = 0; i < arrayExpression.Initializers.Count; i++)
 			{
 				ShouldMatch(array[i], arrayExpression.Initializers[i].Arguments[0] as MemberInitExpression);


### PR DESCRIPTION
Fixes #82 

Let me know if you'd prefer the length check to happen after missing items have been searched for.

(just scratching a few itches I had on my backlog with SpecsFor 😺 )