### PR TITLE
Add BeforeTest and AfterTest hooks to Behaviors

### DIFF
--- a/SpecsFor.Autofac.Tests/ComposingContext/CompositionalContextSpecs.cs
+++ b/SpecsFor.Autofac.Tests/ComposingContext/CompositionalContextSpecs.cs
@@ -12,14 +12,18 @@ namespace SpecsFor.Autofac.Tests.ComposingContext
 			public List<string> CalledBySpecInit { get; set; }
 			public List<string> CalledByApplyAfterClassUnderTestInitialized { get; set; }
 			public List<string> CalledByDuringGiven { get; set; }
+			public List<string> CalledByAfterSpec { get; set; }
 			public List<string> CalledByAfterTest { get; set; }
+			public List<string> CalledByBeforeTest { get; set; }
 
 			protected given_the_default_state()
 			{
 				CalledBySpecInit = new List<string>();
 				CalledByApplyAfterClassUnderTestInitialized = new List<string>();
 				CalledByDuringGiven = new List<string>();
+				CalledByAfterSpec = new List<string>();
 				CalledByAfterTest = new List<string>();
+				CalledByBeforeTest = new List<string>();
 			}
 		}
 
@@ -65,6 +69,26 @@ namespace SpecsFor.Autofac.Tests.ComposingContext
 			public void then_it_invokes_the_class_initialized_phase()
 			{
 				CalledBySpecInit.ShouldContain(typeof(ProvideMagicForEveryone).Name);
+			}
+			
+			[Test]
+			public void then_it_invokes_the_after_test_phase()
+			{
+				CalledByAfterTest.ShouldContain(typeof(ProvideMagicForEveryone).Name);
+				CalledByAfterTest.ShouldContain(typeof(ProvideMagicByInterface).Name);
+				CalledByAfterTest.ShouldContain(typeof(ProvideMagicByConcreteType).Name);
+				CalledByAfterTest.ShouldContain(typeof(ProvideMagicByTypeName).Name);
+				CalledByAfterTest.ShouldNotContain(typeof(DoNotProvideMagic).Name);
+			}
+
+			[Test]
+			public void then_it_invokes_the_before_test_phase()
+			{
+				CalledByBeforeTest.ShouldContain(typeof(ProvideMagicForEveryone).Name);
+				CalledByBeforeTest.ShouldContain(typeof(ProvideMagicByInterface).Name);
+				CalledByBeforeTest.ShouldContain(typeof(ProvideMagicByConcreteType).Name);
+				CalledByBeforeTest.ShouldContain(typeof(ProvideMagicByTypeName).Name);
+				CalledByBeforeTest.ShouldNotContain(typeof(DoNotProvideMagic).Name);
 			}
 		}
 	}

--- a/SpecsFor.Autofac.Tests/ComposingContext/StackingContext/StackingContextConfig.cs
+++ b/SpecsFor.Autofac.Tests/ComposingContext/StackingContext/StackingContextConfig.cs
@@ -22,7 +22,17 @@ namespace SpecsFor.Autofac.Tests.ComposingContext.StackingContext
 
 		public override void AfterSpec(ILikeMagic instance)
 		{
+			instance.CalledByAfterSpec.Add(this.GetType().Name);
+		}
+
+		public override void AfterTest(ILikeMagic instance)
+		{
 			instance.CalledByAfterTest.Add(this.GetType().Name);
+		}
+		
+		public override void BeforeTest(ILikeMagic instance)
+		{
+			instance.CalledByBeforeTest.Add(this.GetType().Name);
 		}
 	}
 }

--- a/SpecsFor.Autofac.Tests/ComposingContext/StackingContext/StackingContextSpecs.cs
+++ b/SpecsFor.Autofac.Tests/ComposingContext/StackingContext/StackingContextSpecs.cs
@@ -11,7 +11,9 @@ namespace SpecsFor.Autofac.Tests.ComposingContext.StackingContext
 		public class when_running_tests_decorated_with_a_behavior : SpecsFor<Widget>, ILikeMagic
 		{
 			public List<string> CalledByDuringGiven { get; set; }
+			public List<string> CalledByAfterSpec { get; set; }
 			public List<string> CalledByAfterTest { get; set; }
+			public List<string> CalledByBeforeTest { get; set; }
 			public List<string> CalledByApplyAfterClassUnderTestInitialized { get; set; }
 			public List<string> CalledBySpecInit { get; set; }
 
@@ -20,7 +22,9 @@ namespace SpecsFor.Autofac.Tests.ComposingContext.StackingContext
 				CalledBySpecInit = new List<string>();
 				CalledByApplyAfterClassUnderTestInitialized = new List<string>();
 				CalledByDuringGiven = new List<string>();
+				CalledByAfterSpec = new List<string>();
 				CalledByAfterTest = new List<string>();
+				CalledByBeforeTest = new List<string>();
 			}
 
 			[Test]

--- a/SpecsFor.Autofac.Tests/ComposingContext/TestDomain/DoNotProvideMagic.cs
+++ b/SpecsFor.Autofac.Tests/ComposingContext/TestDomain/DoNotProvideMagic.cs
@@ -12,7 +12,17 @@ namespace SpecsFor.Autofac.Tests.ComposingContext.TestDomain
 
 		public override void AfterSpec(ISpecs instance)
 		{
+			((ILikeMagic)instance).CalledByAfterSpec.Add(GetType().Name);
+		}
+		
+		public override void AfterTest(ISpecs instance)
+		{
 			((ILikeMagic)instance).CalledByAfterTest.Add(GetType().Name);
+		}
+		
+		public override void BeforeTest(ISpecs instance)
+		{
+			((ILikeMagic)instance).CalledByBeforeTest.Add(GetType().Name);
 		}
 	}
 }

--- a/SpecsFor.Autofac.Tests/ComposingContext/TestDomain/ILikeMagic.cs
+++ b/SpecsFor.Autofac.Tests/ComposingContext/TestDomain/ILikeMagic.cs
@@ -5,7 +5,9 @@ namespace SpecsFor.Autofac.Tests.ComposingContext.TestDomain
 	public interface ILikeMagic
 	{
 		List<string> CalledByDuringGiven { get; set; }
+		List<string> CalledByAfterSpec { get; set; }
 		List<string> CalledByAfterTest { get; set; }
+		List<string> CalledByBeforeTest { get; set; }
 		List<string> CalledByApplyAfterClassUnderTestInitialized { get; set; }
 		List<string> CalledBySpecInit { get; set; }
 	}

--- a/SpecsFor.Autofac.Tests/ComposingContext/TestDomain/MyTestLogger.cs
+++ b/SpecsFor.Autofac.Tests/ComposingContext/TestDomain/MyTestLogger.cs
@@ -19,5 +19,15 @@ namespace SpecsFor.Autofac.Tests.ComposingContext.TestDomain
 		{
 			Console.WriteLine(_stopwatch.Elapsed.TotalSeconds);
 		}
+		
+		public override void AfterTest(ISpecs instance)
+		{
+			Console.WriteLine("After test");
+		}
+		
+		public override void BeforeTest(ISpecs instance)
+		{
+			Console.WriteLine("Before test");
+		}
 	}
 }

--- a/SpecsFor.Autofac.Tests/ComposingContext/TestDomain/ProvideMagicByConcreteType.cs
+++ b/SpecsFor.Autofac.Tests/ComposingContext/TestDomain/ProvideMagicByConcreteType.cs
@@ -11,7 +11,17 @@ namespace SpecsFor.Autofac.Tests.ComposingContext.TestDomain
 
 		public override void AfterSpec(SpecsFor<Widget> instance)
 		{
+			((ILikeMagic)instance).CalledByAfterSpec.Add(GetType().Name);
+		}
+		
+		public override void AfterTest(SpecsFor<Widget> instance)
+		{
 			((ILikeMagic)instance).CalledByAfterTest.Add(GetType().Name);
+		}
+		
+		public override void BeforeTest(SpecsFor<Widget> instance)
+		{
+			((ILikeMagic)instance).CalledByBeforeTest.Add(GetType().Name);
 		}
 	}
 }

--- a/SpecsFor.Autofac.Tests/ComposingContext/TestDomain/ProvideMagicByInterface.cs
+++ b/SpecsFor.Autofac.Tests/ComposingContext/TestDomain/ProvideMagicByInterface.cs
@@ -11,7 +11,17 @@ namespace SpecsFor.Autofac.Tests.ComposingContext.TestDomain
 
 		public override void AfterSpec(ILikeMagic instance)
 		{
+			instance.CalledByAfterSpec.Add(GetType().Name);
+		}
+		
+		public override void AfterTest(ILikeMagic instance)
+		{
 			instance.CalledByAfterTest.Add(GetType().Name);
+		}
+		
+		public override void BeforeTest(ILikeMagic instance)
+		{
+			instance.CalledByBeforeTest.Add(GetType().Name);
 		}
 	}
 }

--- a/SpecsFor.Autofac.Tests/ComposingContext/TestDomain/ProvideMagicByTypeName.cs
+++ b/SpecsFor.Autofac.Tests/ComposingContext/TestDomain/ProvideMagicByTypeName.cs
@@ -12,7 +12,17 @@ namespace SpecsFor.Autofac.Tests.ComposingContext.TestDomain
 
 		public override void AfterSpec(ISpecs instance)
 		{
+			((ILikeMagic)instance).CalledByAfterSpec.Add(GetType().Name);
+		}
+		
+		public override void AfterTest(ISpecs instance)
+		{
 			((ILikeMagic)instance).CalledByAfterTest.Add(GetType().Name);
+		}
+		
+		public override void BeforeTest(ISpecs instance)
+		{
+			((ILikeMagic)instance).CalledByBeforeTest.Add(GetType().Name);
 		}
 	}
 }

--- a/SpecsFor.Autofac.Tests/ComposingContext/TestDomain/ProvideMagicForEveryone.cs
+++ b/SpecsFor.Autofac.Tests/ComposingContext/TestDomain/ProvideMagicForEveryone.cs
@@ -12,7 +12,17 @@ namespace SpecsFor.Autofac.Tests.ComposingContext.TestDomain
 
 		public override void AfterSpec(ISpecs instance)
 		{
+			((ILikeMagic)instance).CalledByAfterSpec.Add(GetType().Name);
+		}
+		
+		public override void AfterTest(ISpecs instance)
+		{
 			((ILikeMagic)instance).CalledByAfterTest.Add(GetType().Name);
+		}
+		
+		public override void BeforeTest(ISpecs instance)
+		{
+			((ILikeMagic)instance).CalledByBeforeTest.Add(GetType().Name);
 		}
 
 		public override void ClassUnderTestInitialized(ISpecs instance)

--- a/SpecsFor.Autofac.Tests/ComposingContext/TestDomain/Widget.cs
+++ b/SpecsFor.Autofac.Tests/ComposingContext/TestDomain/Widget.cs
@@ -5,7 +5,9 @@ namespace SpecsFor.Autofac.Tests.ComposingContext.TestDomain
 	public class Widget : ILikeMagic
 	{
 		public List<string> CalledByDuringGiven { get; set; }
+		public List<string> CalledByAfterSpec { get; set; }
 		public List<string> CalledByAfterTest { get; set; }
+		public List<string> CalledByBeforeTest { get; set; }
 		public List<string> CalledByApplyAfterClassUnderTestInitialized { get; set; }
 		public List<string> CalledBySpecInit { get; set; }
 
@@ -14,7 +16,9 @@ namespace SpecsFor.Autofac.Tests.ComposingContext.TestDomain
 			CalledBySpecInit = new List<string>();
 			CalledByApplyAfterClassUnderTestInitialized = new List<string>();
 			CalledByDuringGiven = new List<string>();
+			CalledByAfterSpec = new List<string>();
 			CalledByAfterTest = new List<string>();
+			CalledByBeforeTest = new List<string>();
 		}
 	}
 }

--- a/SpecsFor.Autofac.Tests/SpecsForEngineSpecs.cs
+++ b/SpecsFor.Autofac.Tests/SpecsForEngineSpecs.cs
@@ -361,5 +361,33 @@ namespace SpecsFor.Autofac.Tests
 					.Verify(d => d.Dispose());
 			}
 		}
+		
+		internal class when_running_the_after_test_stage : SpecsFor<SpecsForEngine<object>>
+		{
+			protected override void When()
+			{
+				SUT.AfterTest();
+			}
+
+			[Test]
+			public void then_it_runs_the_after_test_callback_on_the_behaviors()
+			{
+				GetMockFor<IBehaviorStack>().Verify(m=>m.ApplyAfterTestTo(It.IsAny<ISpecs<object>>()));
+			}
+		}
+    
+		internal class when_running_the_before_test_stage : SpecsFor<SpecsForEngine<object>>
+		{
+			protected override void When()
+			{
+				SUT.BeforeTest();
+			}
+
+			[Test]
+			public void then_it_runs_the_before_test_callback_on_the_behaviors()
+			{
+				GetMockFor<IBehaviorStack>().Verify(m=>m.ApplyBeforeTestTo(It.IsAny<ISpecs<object>>()));
+			}
+		}
 	}
 }

--- a/SpecsFor.Autofac.Tests/SpecsForSpecs.cs
+++ b/SpecsFor.Autofac.Tests/SpecsForSpecs.cs
@@ -146,7 +146,7 @@ namespace SpecsFor.Autofac.Tests
             }
 
             [Test]
-            public void then_it_uses_the_conrete_class()
+            public void then_it_uses_the_concrete_class()
             {
                 _result.ShouldEqual(20);
             }

--- a/SpecsFor.Core/Configuration/Behavior.cs
+++ b/SpecsFor.Core/Configuration/Behavior.cs
@@ -21,5 +21,13 @@ namespace SpecsFor.Core.Configuration
 		public virtual void AfterSpec(T instance)
 		{
 		}
+
+		public virtual void AfterTest(T instance)
+		{
+		}
+
+		public virtual void BeforeTest(T instance)
+		{
+		}
 	}
 }

--- a/SpecsFor.Core/Configuration/Model/BehaviorStack.cs
+++ b/SpecsFor.Core/Configuration/Model/BehaviorStack.cs
@@ -79,6 +79,26 @@ namespace SpecsFor.Core.Configuration.Model
 			}
 		}
 
+		public void ApplyAfterTestTo(ISpecs specs)
+		{
+			var behaviors = FindBehaviorsFor(specs);
+
+			foreach (var behavior in behaviors)
+			{
+				behavior.ApplyAfterTestTo(specs);
+			}
+		}
+
+		public void ApplyBeforeTestTo(ISpecs specs)
+		{
+			var behaviors = FindBehaviorsFor(specs);
+
+			foreach (var behavior in behaviors)
+			{
+				behavior.ApplyBeforeTestTo(specs);
+			}
+		}
+
 		public void ApplySpecInitTo(ISpecs specs)
 		{
 			var behaviors = FindBehaviorsFor(specs);

--- a/SpecsFor.Core/Configuration/Model/ConditionalBehavior.cs
+++ b/SpecsFor.Core/Configuration/Model/ConditionalBehavior.cs
@@ -33,6 +33,16 @@ namespace SpecsFor.Core.Configuration.Model
 			_behavior.AfterSpec((TSpec)specs);
 		}
 
+		public void ApplyAfterTestTo(object specs)
+		{
+			_behavior.AfterTest((TSpec) specs);
+		}
+		
+		public void ApplyBeforeTestTo(object specs)
+		{
+			_behavior.BeforeTest((TSpec) specs);
+		}
+
 		public void ApplySpecInitTo(object specs)
 		{
 			_behavior.SpecInit((TSpec)specs);

--- a/SpecsFor.Core/Configuration/Model/IBehaviorStack.cs
+++ b/SpecsFor.Core/Configuration/Model/IBehaviorStack.cs
@@ -9,6 +9,8 @@ namespace SpecsFor.Core.Configuration.Model
 		void ApplyGivenTo(ISpecs specs);
 		void ApplyAfterGivenTo(ISpecs specs);
 		void ApplyAfterSpecTo(ISpecs specs);
+		void ApplyAfterTestTo(ISpecs specs);
+		void ApplyBeforeTestTo(ISpecs specs);
 		Func<object> GetInitializationMethodFor(ISpecs specs);
 	}
 }

--- a/SpecsFor.Core/Configuration/Model/IConditionalBehavior.cs
+++ b/SpecsFor.Core/Configuration/Model/IConditionalBehavior.cs
@@ -2,13 +2,15 @@ using System;
 
 namespace SpecsFor.Core.Configuration.Model
 {
-	internal interface IConditionalBehavior
-	{
-		bool CanBeAppliedTo(Type targetType);
-		void ApplyGivenTo(object specs);
-		void ApplyAfterGivenTo(object specs);
-		void ApplyAfterSpecTo(object specs);
-		void ApplySpecInitTo(object specs);
-		void ApplyAfterClassUnderTestInitializedTo(object specs);
-	}
+    internal interface IConditionalBehavior
+    {
+        bool CanBeAppliedTo(Type targetType);
+        void ApplyGivenTo(object specs);
+        void ApplyAfterGivenTo(object specs);
+        void ApplyAfterSpecTo(object specs);
+        void ApplySpecInitTo(object specs);
+        void ApplyAfterTestTo(object specs);
+        void ApplyBeforeTestTo(object specs);
+        void ApplyAfterClassUnderTestInitializedTo(object specs);
+    }
 }

--- a/SpecsFor.Core/ISpecs.cs
+++ b/SpecsFor.Core/ISpecs.cs
@@ -17,6 +17,10 @@ namespace SpecsFor.Core
 		void When();
 
 		void AfterSpec();
+		
+		void AfterTest();
+
+		void BeforeTest();
 	}
 
 	public interface ISpecs<T> : ISpecs

--- a/SpecsFor.Core/SpecsForBase.cs
+++ b/SpecsFor.Core/SpecsForBase.cs
@@ -79,20 +79,29 @@ namespace SpecsFor.Core
 		protected virtual void When()
 		{
 		}
-
+        
+        [SetUp]
+        protected void BeforeTest()
+        {
+	        _engine.BeforeTest();
+		}
+        
         /// <summary>
         /// Runs before each individual test case.  Use carefully!
         /// </summary>
-        [SetUp]
 	    protected virtual void BeforeEachTest()
 	    {
-	        
 	    }
 
-        /// <summary>
-        /// Runs after each individual test case.  Use carefully!
-        /// </summary>
-        [TearDown]
+	    [TearDown]
+	    protected void AfterTest()
+	    {
+		    _engine.AfterTest();
+	    }
+	    
+	    /// <summary>
+	    /// Runs after each individual test case.  Use carefully!
+	    /// </summary>
 		protected virtual void AfterEachTest()
 		{
 		}
@@ -141,6 +150,16 @@ namespace SpecsFor.Core
 		void ISpecs.AfterSpec()
 		{
 			AfterSpec();
+		}
+
+		void ISpecs.AfterTest()
+		{
+			AfterEachTest();
+		}
+
+		void ISpecs.BeforeTest()
+		{
+			BeforeEachTest();
 		}
         
         #endregion

--- a/SpecsFor.Core/SpecsForEngine.cs
+++ b/SpecsFor.Core/SpecsForEngine.cs
@@ -119,6 +119,40 @@ namespace SpecsFor.Core
 			}
 		}
 
+		public void AfterTest()
+		{
+			try
+			{
+				_specs.AfterTest();
+
+				_currentBehaviors.ApplyAfterTestTo(_specs);
+			}
+			catch (Exception ex)
+			{
+				_exceptions.Add(ex);
+				HandleError();
+				TryDisposeSUT();
+				throw new GivenSpecificationException(_exceptions.ToArray());
+			}
+		}
+
+		public void BeforeTest()
+		{
+			try
+			{
+				_specs.BeforeTest();
+
+				_currentBehaviors.ApplyBeforeTestTo(_specs);
+			}
+			catch (Exception ex)
+			{
+				_exceptions.Add(ex);
+				HandleError();
+				TryDisposeSUT();
+				throw new GivenSpecificationException(_exceptions.ToArray());
+			}
+		}
+
 		private void TryDisposeSUT()
 		{
 		    if (!(SUT is IDisposable sut)) return;

--- a/SpecsFor.Lamar.Tests/ComposingContext/CompositionalContextSpecs.cs
+++ b/SpecsFor.Lamar.Tests/ComposingContext/CompositionalContextSpecs.cs
@@ -12,7 +12,9 @@ public class CompositionalContextSpecs
         public List<string> CalledByApplyAfterClassUnderTestInitialized { get; set; }
         public List<string> CalledByDuringGiven { get; set; }
         public List<string> CalledByAfterGiven { get; set; }
+        public List<string> CalledByAfterSpec { get; set; }
         public List<string> CalledByAfterTest { get; set; }
+        public List<string> CalledByBeforeTest { get; set; }
 
         protected given_the_default_state()
         {
@@ -20,7 +22,9 @@ public class CompositionalContextSpecs
             CalledByApplyAfterClassUnderTestInitialized = new List<string>();
             CalledByDuringGiven = new List<string>();
             CalledByAfterGiven = new List<string>();
+            CalledByAfterSpec = new List<string>();
             CalledByAfterTest = new List<string>();
+            CalledByBeforeTest = new List<string>();
         }
     }
 
@@ -71,6 +75,26 @@ public class CompositionalContextSpecs
         public void then_it_invokes_the_class_initialized_phase()
         {
             CalledBySpecInit.ShouldContain(typeof(ProvideMagicForEveryone).Name);
+        }
+        
+        [Test]
+        public void then_it_invokes_the_after_test_phase()
+        {
+            CalledByAfterTest.ShouldContain(typeof(ProvideMagicForEveryone).Name);
+            CalledByAfterTest.ShouldContain(typeof(ProvideMagicByInterface).Name);
+            CalledByAfterTest.ShouldContain(typeof(ProvideMagicByConcreteType).Name);
+            CalledByAfterTest.ShouldContain(typeof(ProvideMagicByTypeName).Name);
+            CalledByAfterTest.ShouldNotContain(typeof(DoNotProvideMagic).Name);
+        }
+
+        [Test]
+        public void then_it_invokes_the_before_test_phase()
+        {
+            CalledByBeforeTest.ShouldContain(typeof(ProvideMagicForEveryone).Name);
+            CalledByBeforeTest.ShouldContain(typeof(ProvideMagicByInterface).Name);
+            CalledByBeforeTest.ShouldContain(typeof(ProvideMagicByConcreteType).Name);
+            CalledByBeforeTest.ShouldContain(typeof(ProvideMagicByTypeName).Name);
+            CalledByBeforeTest.ShouldNotContain(typeof(DoNotProvideMagic).Name);
         }
     }
 }

--- a/SpecsFor.Lamar.Tests/ComposingContext/StackingContext/StackingContextConfig.cs
+++ b/SpecsFor.Lamar.Tests/ComposingContext/StackingContext/StackingContextConfig.cs
@@ -27,6 +27,16 @@ public class NestedMagicProvider : Behavior<ILikeMagic>
 
     public override void AfterSpec(ILikeMagic instance)
     {
-        instance.CalledByAfterTest.Add(this.GetType().Name);
+        instance.CalledByAfterSpec.Add(this.GetType().Name);
+    }
+    
+    public override void AfterTest(ILikeMagic instance)
+    {
+        instance.CalledByAfterSpec.Add(this.GetType().Name);
+    }
+		
+    public override void BeforeTest(ILikeMagic instance)
+    {
+        instance.CalledByBeforeTest.Add(this.GetType().Name);
     }
 }

--- a/SpecsFor.Lamar.Tests/ComposingContext/StackingContext/StackingContextSpecs.cs
+++ b/SpecsFor.Lamar.Tests/ComposingContext/StackingContext/StackingContextSpecs.cs
@@ -10,7 +10,9 @@ public class StackingContextSpecs
     {
         public List<string> CalledByDuringGiven { get; set; }
         public List<string> CalledByAfterGiven { get; set; }
+        public List<string> CalledByAfterSpec { get; set; }
         public List<string> CalledByAfterTest { get; set; }
+        public List<string> CalledByBeforeTest { get; set; }
         public List<string> CalledByApplyAfterClassUnderTestInitialized { get; set; }
         public List<string> CalledBySpecInit { get; set; }
 
@@ -20,7 +22,9 @@ public class StackingContextSpecs
             CalledByApplyAfterClassUnderTestInitialized = new List<string>();
             CalledByDuringGiven = new List<string>();
             CalledByAfterGiven = new List<string>();
+            CalledByAfterSpec = new List<string>();
             CalledByAfterTest = new List<string>();
+            CalledByBeforeTest = new List<string>();
         }
 
         [Test]

--- a/SpecsFor.Lamar.Tests/ComposingContext/TestDomain/DoNotProvideMagic.cs
+++ b/SpecsFor.Lamar.Tests/ComposingContext/TestDomain/DoNotProvideMagic.cs
@@ -17,6 +17,16 @@ public class DoNotProvideMagic : Behavior<ISpecs>
 
     public override void AfterSpec(ISpecs instance)
     {
+        ((ILikeMagic)instance).CalledByAfterSpec.Add(GetType().Name);
+    }
+    
+    public override void AfterTest(ISpecs instance)
+    {
         ((ILikeMagic)instance).CalledByAfterTest.Add(GetType().Name);
+    }
+    
+    public override void BeforeTest(ISpecs instance)
+    {
+        ((ILikeMagic)instance).CalledByBeforeTest.Add(GetType().Name);
     }
 }

--- a/SpecsFor.Lamar.Tests/ComposingContext/TestDomain/ILikeMagic.cs
+++ b/SpecsFor.Lamar.Tests/ComposingContext/TestDomain/ILikeMagic.cs
@@ -4,7 +4,9 @@ public interface ILikeMagic
 {
     List<string> CalledByDuringGiven { get; set; }
     List<string> CalledByAfterGiven { get; set; }
+    List<string> CalledByAfterSpec { get; set; }
     List<string> CalledByAfterTest { get; set; }
+    List<string> CalledByBeforeTest { get; set; }
     List<string> CalledByApplyAfterClassUnderTestInitialized { get; set; }
     List<string> CalledBySpecInit { get; set; }
 }

--- a/SpecsFor.Lamar.Tests/ComposingContext/TestDomain/MyTestLogger.cs
+++ b/SpecsFor.Lamar.Tests/ComposingContext/TestDomain/MyTestLogger.cs
@@ -18,4 +18,14 @@ public class MyTestLogger : Behavior<ISpecs>
     {
         Console.WriteLine(_stopwatch.Elapsed.TotalSeconds);
     }
+
+    public override void AfterTest(ISpecs instance)
+    {
+        Console.WriteLine("After test");
+    }
+    
+    public override void BeforeTest(ISpecs instance)
+    {
+        Console.WriteLine("Before test");
+    }
 }

--- a/SpecsFor.Lamar.Tests/ComposingContext/TestDomain/ProvideMagicByConcreteType.cs
+++ b/SpecsFor.Lamar.Tests/ComposingContext/TestDomain/ProvideMagicByConcreteType.cs
@@ -16,6 +16,16 @@ public class ProvideMagicByConcreteType : Behavior<SpecsFor<Widget>>
 
     public override void AfterSpec(SpecsFor<Widget> instance)
     {
+        ((ILikeMagic)instance).CalledByAfterSpec.Add(GetType().Name);
+    }
+    
+    public override void AfterTest(SpecsFor<Widget> instance)
+    {
         ((ILikeMagic)instance).CalledByAfterTest.Add(GetType().Name);
+    }
+    
+    public override void BeforeTest(SpecsFor<Widget> instance)
+    {
+        ((ILikeMagic)instance).CalledByBeforeTest.Add(GetType().Name);
     }
 }

--- a/SpecsFor.Lamar.Tests/ComposingContext/TestDomain/ProvideMagicByInterface.cs
+++ b/SpecsFor.Lamar.Tests/ComposingContext/TestDomain/ProvideMagicByInterface.cs
@@ -16,6 +16,16 @@ public class ProvideMagicByInterface : Behavior<ILikeMagic>
 
     public override void AfterSpec(ILikeMagic instance)
     {
+        instance.CalledByAfterSpec.Add(GetType().Name);
+    }
+    
+    public override void AfterTest(ILikeMagic instance)
+    {
         instance.CalledByAfterTest.Add(GetType().Name);
+    }
+    
+    public override void BeforeTest(ILikeMagic instance)
+    {
+        instance.CalledByBeforeTest.Add(GetType().Name);
     }
 }

--- a/SpecsFor.Lamar.Tests/ComposingContext/TestDomain/ProvideMagicByTypeName.cs
+++ b/SpecsFor.Lamar.Tests/ComposingContext/TestDomain/ProvideMagicByTypeName.cs
@@ -17,6 +17,16 @@ public class ProvideMagicByTypeName : Behavior<ISpecs>
 
     public override void AfterSpec(ISpecs instance)
     {
+        ((ILikeMagic)instance).CalledByAfterSpec.Add(GetType().Name);
+    }
+    
+    public override void AfterTest(ISpecs instance)
+    {
         ((ILikeMagic)instance).CalledByAfterTest.Add(GetType().Name);
+    }
+    
+    public override void BeforeTest(ISpecs instance)
+    {
+        ((ILikeMagic)instance).CalledByBeforeTest.Add(GetType().Name);
     }
 }

--- a/SpecsFor.Lamar.Tests/ComposingContext/TestDomain/ProvideMagicForEveryone.cs
+++ b/SpecsFor.Lamar.Tests/ComposingContext/TestDomain/ProvideMagicForEveryone.cs
@@ -17,7 +17,17 @@ public class ProvideMagicForEveryone : Behavior<ISpecs>
 
     public override void AfterSpec(ISpecs instance)
     {
+        ((ILikeMagic)instance).CalledByAfterSpec.Add(GetType().Name);
+    }
+    
+    public override void AfterTest(ISpecs instance)
+    {
         ((ILikeMagic)instance).CalledByAfterTest.Add(GetType().Name);
+    }
+    
+    public override void BeforeTest(ISpecs instance)
+    {
+        ((ILikeMagic)instance).CalledByBeforeTest.Add(GetType().Name);
     }
 
     public override void ClassUnderTestInitialized(ISpecs instance)

--- a/SpecsFor.Lamar.Tests/ComposingContext/TestDomain/Widget.cs
+++ b/SpecsFor.Lamar.Tests/ComposingContext/TestDomain/Widget.cs
@@ -4,7 +4,9 @@ public class Widget : ILikeMagic
 {
     public List<string> CalledByDuringGiven { get; set; }
     public List<string> CalledByAfterGiven { get; set; }
+    public List<string> CalledByAfterSpec { get; set; }
     public List<string> CalledByAfterTest { get; set; }
+    public List<string> CalledByBeforeTest { get; set; }
     public List<string> CalledByApplyAfterClassUnderTestInitialized { get; set; }
     public List<string> CalledBySpecInit { get; set; }
 
@@ -14,6 +16,8 @@ public class Widget : ILikeMagic
         CalledByApplyAfterClassUnderTestInitialized = new List<string>();
         CalledByDuringGiven = new List<string>();
         CalledByAfterGiven = new List<string>();
+        CalledByAfterSpec = new List<string>();
         CalledByAfterTest = new List<string>();
+        CalledByBeforeTest = new List<string>();
     }
 }

--- a/SpecsFor.Lamar.Tests/SpecsForEngineSpecs.cs
+++ b/SpecsFor.Lamar.Tests/SpecsForEngineSpecs.cs
@@ -360,4 +360,32 @@ internal class SpecsForEngineSpecs
                 .Verify(d => d.Dispose());
         }
     }
+
+    internal class when_running_the_after_test_stage : SpecsFor<SpecsForEngine<object>>
+    {
+        protected override void When()
+        {
+            SUT.AfterTest();
+        }
+
+        [Test]
+        public void then_it_runs_the_after_test_callback_on_the_behaviors()
+        {
+            GetMockFor<IBehaviorStack>().Verify(m => m.ApplyAfterTestTo(It.IsAny<ISpecs<object>>()));
+        }
+    }
+
+    internal class when_running_the_before_test_stage : SpecsFor<SpecsForEngine<object>>
+    {
+        protected override void When()
+        {
+            SUT.BeforeTest();
+        }
+
+        [Test]
+        public void then_it_runs_the_before_test_callback_on_the_behaviors()
+        {
+            GetMockFor<IBehaviorStack>().Verify(m => m.ApplyBeforeTestTo(It.IsAny<ISpecs<object>>()));
+        }
+    }
 }

--- a/SpecsFor.Lamar.Tests/SpecsForSpecs.cs
+++ b/SpecsFor.Lamar.Tests/SpecsForSpecs.cs
@@ -119,7 +119,7 @@ public class SpecsForSpecs
         }
 
         [Test]
-        public void then_it_uses_the_conrete_class()
+        public void then_it_uses_the_concrete_class()
         {
             _result.ShouldEqual(6);
         }

--- a/SpecsFor.StructureMap.Tests/ComposingContext/CompositionalContextSpecs.cs
+++ b/SpecsFor.StructureMap.Tests/ComposingContext/CompositionalContextSpecs.cs
@@ -5,74 +5,98 @@ using SpecsFor.StructureMap.Tests.ComposingContext.TestDomain;
 
 namespace SpecsFor.StructureMap.Tests.ComposingContext
 {
-	public class CompositionalContextSpecs
-	{
-		public abstract class given_the_default_state : SpecsFor<Widget>, ILikeMagic
-		{
-			public List<string> CalledBySpecInit { get; set; }
-			public List<string> CalledByApplyAfterClassUnderTestInitialized { get; set; }
-			public List<string> CalledByDuringGiven { get; set; }
-			public List<string> CalledByAfterGiven { get; set; }
-			public List<string> CalledByAfterTest { get; set; }
+    public class CompositionalContextSpecs
+    {
+        public abstract class given_the_default_state : SpecsFor<Widget>, ILikeMagic
+        {
+            public List<string> CalledBySpecInit { get; set; }
+            public List<string> CalledByApplyAfterClassUnderTestInitialized { get; set; }
+            public List<string> CalledByDuringGiven { get; set; }
+            public List<string> CalledByAfterGiven { get; set; }
+            public List<string> CalledByAfterSpec { get; set; }
+            public List<string> CalledByAfterTest { get; set; }
+            public List<string> CalledByBeforeTest { get; set; }
 
-			protected given_the_default_state()
-			{
-				CalledBySpecInit = new List<string>();
-				CalledByApplyAfterClassUnderTestInitialized = new List<string>();
-				CalledByDuringGiven = new List<string>();
-				CalledByAfterGiven = new List<string>();
-				CalledByAfterTest = new List<string>();
-			}
-		}
+            protected given_the_default_state()
+            {
+                CalledBySpecInit = new List<string>();
+                CalledByApplyAfterClassUnderTestInitialized = new List<string>();
+                CalledByDuringGiven = new List<string>();
+                CalledByAfterGiven = new List<string>();
+                CalledByAfterSpec = new List<string>();
+                CalledByAfterTest = new List<string>();
+                CalledByBeforeTest = new List<string>();
+            }
+        }
 
-		public class when_running_tests_decorated_with_a_behavior : given_the_default_state
-		{
-			[Test]
-			public void then_handlers_for_the_interface_are_called()
-			{
-				CalledByDuringGiven.ShouldContain(typeof(ProvideMagicByInterface).Name);
-				CalledByAfterGiven.ShouldContain(typeof(ProvideMagicByInterface).Name);
-			}
+        public class when_running_tests_decorated_with_a_behavior : given_the_default_state
+        {
+            [Test]
+            public void then_handlers_for_the_interface_are_called()
+            {
+                CalledByDuringGiven.ShouldContain(typeof(ProvideMagicByInterface).Name);
+                CalledByAfterGiven.ShouldContain(typeof(ProvideMagicByInterface).Name);
+            }
 
-			[Test]
-			public void then_handlers_for_the_type_are_called()
-			{
-				CalledByDuringGiven.ShouldContain(typeof (ProvideMagicByConcreteType).Name);
-				CalledByAfterGiven.ShouldContain(typeof (ProvideMagicByConcreteType).Name);
-			}
+            [Test]
+            public void then_handlers_for_the_type_are_called()
+            {
+                CalledByDuringGiven.ShouldContain(typeof(ProvideMagicByConcreteType).Name);
+                CalledByAfterGiven.ShouldContain(typeof(ProvideMagicByConcreteType).Name);
+            }
 
-			[Test]
-			public void then_handlers_for_names_are_called()
-			{
-				CalledByDuringGiven.ShouldContain(typeof (ProvideMagicByTypeName).Name);
-				CalledByAfterGiven.ShouldContain(typeof (ProvideMagicByTypeName).Name);
-			}
+            [Test]
+            public void then_handlers_for_names_are_called()
+            {
+                CalledByDuringGiven.ShouldContain(typeof(ProvideMagicByTypeName).Name);
+                CalledByAfterGiven.ShouldContain(typeof(ProvideMagicByTypeName).Name);
+            }
 
-			[Test]
-			public void then_handlers_that_do_not_match_should_not_be_called()
-			{
-				CalledByDuringGiven.ShouldNotContain(typeof (DoNotProvideMagic).Name);
-				CalledByAfterGiven.ShouldNotContain(typeof (DoNotProvideMagic).Name);
-			}
+            [Test]
+            public void then_handlers_that_do_not_match_should_not_be_called()
+            {
+                CalledByDuringGiven.ShouldNotContain(typeof(DoNotProvideMagic).Name);
+                CalledByAfterGiven.ShouldNotContain(typeof(DoNotProvideMagic).Name);
+            }
 
-			[Test]
-			public void then_handlers_for_all_types_are_called()
-			{
-				CalledByDuringGiven.ShouldContain(typeof(ProvideMagicForEveryone).Name);
-				CalledByAfterGiven.ShouldContain(typeof(ProvideMagicForEveryone).Name);
-			}
+            [Test]
+            public void then_handlers_for_all_types_are_called()
+            {
+                CalledByDuringGiven.ShouldContain(typeof(ProvideMagicForEveryone).Name);
+                CalledByAfterGiven.ShouldContain(typeof(ProvideMagicForEveryone).Name);
+            }
 
-			[Test]
-			public void then_it_invokes_the_handlers_during_the_init_phase()
-			{
-				CalledBySpecInit.ShouldContain(typeof(ProvideMagicForEveryone).Name);
-			}
+            [Test]
+            public void then_it_invokes_the_handlers_during_the_init_phase()
+            {
+                CalledBySpecInit.ShouldContain(typeof(ProvideMagicForEveryone).Name);
+            }
 
-			[Test]
-			public void then_it_invokes_the_class_initialized_phase()
-			{
-				CalledBySpecInit.ShouldContain(typeof(ProvideMagicForEveryone).Name);
-			}
-		}
-	}
+            [Test]
+            public void then_it_invokes_the_class_initialized_phase()
+            {
+                CalledBySpecInit.ShouldContain(typeof(ProvideMagicForEveryone).Name);
+            }
+
+            [Test]
+            public void then_it_invokes_the_after_test_phase()
+            {
+                CalledByAfterTest.ShouldContain(typeof(ProvideMagicForEveryone).Name);
+                CalledByAfterTest.ShouldContain(typeof(ProvideMagicByInterface).Name);
+                CalledByAfterTest.ShouldContain(typeof(ProvideMagicByConcreteType).Name);
+                CalledByAfterTest.ShouldContain(typeof(ProvideMagicByTypeName).Name);
+                CalledByAfterTest.ShouldNotContain(typeof(DoNotProvideMagic).Name);
+            }
+
+            [Test]
+            public void then_it_invokes_the_before_test_phase()
+            {
+                CalledByBeforeTest.ShouldContain(typeof(ProvideMagicForEveryone).Name);
+                CalledByBeforeTest.ShouldContain(typeof(ProvideMagicByInterface).Name);
+                CalledByBeforeTest.ShouldContain(typeof(ProvideMagicByConcreteType).Name);
+                CalledByBeforeTest.ShouldContain(typeof(ProvideMagicByTypeName).Name);
+                CalledByBeforeTest.ShouldNotContain(typeof(DoNotProvideMagic).Name);
+            }
+        }
+    }
 }

--- a/SpecsFor.StructureMap.Tests/ComposingContext/StackingContext/StackingContextConfig.cs
+++ b/SpecsFor.StructureMap.Tests/ComposingContext/StackingContext/StackingContextConfig.cs
@@ -27,7 +27,17 @@ namespace SpecsFor.StructureMap.Tests.ComposingContext.StackingContext
 
 		public override void AfterSpec(ILikeMagic instance)
 		{
+			instance.CalledByAfterSpec.Add(this.GetType().Name);
+		}
+		
+		public override void AfterTest(ILikeMagic instance)
+		{
 			instance.CalledByAfterTest.Add(this.GetType().Name);
+		}
+		
+		public override void BeforeTest(ILikeMagic instance)
+		{
+			instance.CalledByBeforeTest.Add(this.GetType().Name);
 		}
 	}
 }

--- a/SpecsFor.StructureMap.Tests/ComposingContext/StackingContext/StackingContextSpecs.cs
+++ b/SpecsFor.StructureMap.Tests/ComposingContext/StackingContext/StackingContextSpecs.cs
@@ -12,7 +12,9 @@ namespace SpecsFor.StructureMap.Tests.ComposingContext.StackingContext
 		{
 			public List<string> CalledByDuringGiven { get; set; }
 			public List<string> CalledByAfterGiven { get; set; }
+			public List<string> CalledByAfterSpec { get; set; }
 			public List<string> CalledByAfterTest { get; set; }
+			public List<string> CalledByBeforeTest { get; set; }
 			public List<string> CalledByApplyAfterClassUnderTestInitialized { get; set; }
 			public List<string> CalledBySpecInit { get; set; }
 
@@ -22,7 +24,9 @@ namespace SpecsFor.StructureMap.Tests.ComposingContext.StackingContext
 				CalledByApplyAfterClassUnderTestInitialized = new List<string>();
 				CalledByDuringGiven = new List<string>();
 				CalledByAfterGiven = new List<string>();
+				CalledByAfterSpec = new List<string>();
 				CalledByAfterTest = new List<string>();
+				CalledByBeforeTest = new List<string>();
 			}
 
 			[Test]

--- a/SpecsFor.StructureMap.Tests/ComposingContext/TestDomain/DoNotProvideMagic.cs
+++ b/SpecsFor.StructureMap.Tests/ComposingContext/TestDomain/DoNotProvideMagic.cs
@@ -17,7 +17,17 @@ namespace SpecsFor.StructureMap.Tests.ComposingContext.TestDomain
 
 		public override void AfterSpec(ISpecs instance)
 		{
+			((ILikeMagic)instance).CalledByAfterSpec.Add(GetType().Name);
+		}
+		
+		public override void AfterTest(ISpecs instance)
+		{
 			((ILikeMagic)instance).CalledByAfterTest.Add(GetType().Name);
+		}
+    
+		public override void BeforeTest(ISpecs instance)
+		{
+			((ILikeMagic)instance).CalledByBeforeTest.Add(GetType().Name);
 		}
 	}
 }

--- a/SpecsFor.StructureMap.Tests/ComposingContext/TestDomain/ILikeMagic.cs
+++ b/SpecsFor.StructureMap.Tests/ComposingContext/TestDomain/ILikeMagic.cs
@@ -6,7 +6,9 @@ namespace SpecsFor.StructureMap.Tests.ComposingContext.TestDomain
 	{
 		List<string> CalledByDuringGiven { get; set; }
 		List<string> CalledByAfterGiven { get; set; }
+		List<string> CalledByAfterSpec { get; set; }
 		List<string> CalledByAfterTest { get; set; }
+		List<string> CalledByBeforeTest { get; set; }
 		List<string> CalledByApplyAfterClassUnderTestInitialized { get; set; }
 		List<string> CalledBySpecInit { get; set; }
 	}

--- a/SpecsFor.StructureMap.Tests/ComposingContext/TestDomain/MyTestLogger.cs
+++ b/SpecsFor.StructureMap.Tests/ComposingContext/TestDomain/MyTestLogger.cs
@@ -19,5 +19,15 @@ namespace SpecsFor.StructureMap.Tests.ComposingContext.TestDomain
 		{
 			Console.WriteLine(_stopwatch.Elapsed.TotalSeconds);
 		}
+
+		public override void AfterTest(ISpecs instance)
+		{
+			Console.WriteLine("After test");
+		}
+		
+		public override void BeforeTest(ISpecs instance)
+		{
+			Console.WriteLine("Before test");
+		}
 	}
 }

--- a/SpecsFor.StructureMap.Tests/ComposingContext/TestDomain/ProvideMagicByConcreteType.cs
+++ b/SpecsFor.StructureMap.Tests/ComposingContext/TestDomain/ProvideMagicByConcreteType.cs
@@ -16,7 +16,17 @@ namespace SpecsFor.StructureMap.Tests.ComposingContext.TestDomain
 
 		public override void AfterSpec(SpecsFor<Widget> instance)
 		{
+			((ILikeMagic)instance).CalledByAfterSpec.Add(GetType().Name);
+		}
+		
+		public override void AfterTest(SpecsFor<Widget> instance)
+		{
 			((ILikeMagic)instance).CalledByAfterTest.Add(GetType().Name);
+		}
+		
+		public override void BeforeTest(SpecsFor<Widget> instance)
+		{
+			((ILikeMagic)instance).CalledByBeforeTest.Add(GetType().Name);
 		}
 	}
 }

--- a/SpecsFor.StructureMap.Tests/ComposingContext/TestDomain/ProvideMagicByInterface.cs
+++ b/SpecsFor.StructureMap.Tests/ComposingContext/TestDomain/ProvideMagicByInterface.cs
@@ -16,7 +16,17 @@ namespace SpecsFor.StructureMap.Tests.ComposingContext.TestDomain
 
 		public override void AfterSpec(ILikeMagic instance)
 		{
+			instance.CalledByAfterSpec.Add(GetType().Name);
+		}
+		
+		public override void AfterTest(ILikeMagic instance)
+		{
 			instance.CalledByAfterTest.Add(GetType().Name);
+		}
+		
+		public override void BeforeTest(ILikeMagic instance)
+		{
+			instance.CalledByBeforeTest.Add(GetType().Name);
 		}
 	}
 }

--- a/SpecsFor.StructureMap.Tests/ComposingContext/TestDomain/ProvideMagicByTypeName.cs
+++ b/SpecsFor.StructureMap.Tests/ComposingContext/TestDomain/ProvideMagicByTypeName.cs
@@ -17,7 +17,17 @@ namespace SpecsFor.StructureMap.Tests.ComposingContext.TestDomain
 
 		public override void AfterSpec(ISpecs instance)
 		{
+			((ILikeMagic)instance).CalledByAfterSpec.Add(GetType().Name);
+		}
+		
+		public override void AfterTest(ISpecs instance)
+		{
 			((ILikeMagic)instance).CalledByAfterTest.Add(GetType().Name);
+		}
+		
+		public override void BeforeTest(ISpecs instance)
+		{
+			((ILikeMagic)instance).CalledByBeforeTest.Add(GetType().Name);
 		}
 	}
 }

--- a/SpecsFor.StructureMap.Tests/ComposingContext/TestDomain/ProvideMagicForEveryone.cs
+++ b/SpecsFor.StructureMap.Tests/ComposingContext/TestDomain/ProvideMagicForEveryone.cs
@@ -17,7 +17,17 @@ namespace SpecsFor.StructureMap.Tests.ComposingContext.TestDomain
 
 		public override void AfterSpec(ISpecs instance)
 		{
+			((ILikeMagic)instance).CalledByAfterSpec.Add(GetType().Name);
+		}
+		
+		public override void AfterTest(ISpecs instance)
+		{
 			((ILikeMagic)instance).CalledByAfterTest.Add(GetType().Name);
+		}
+		
+		public override void BeforeTest(ISpecs instance)
+		{
+			((ILikeMagic)instance).CalledByBeforeTest.Add(GetType().Name);
 		}
 
 		public override void ClassUnderTestInitialized(ISpecs instance)

--- a/SpecsFor.StructureMap.Tests/ComposingContext/TestDomain/Widget.cs
+++ b/SpecsFor.StructureMap.Tests/ComposingContext/TestDomain/Widget.cs
@@ -6,7 +6,9 @@ namespace SpecsFor.StructureMap.Tests.ComposingContext.TestDomain
 	{
 		public List<string> CalledByDuringGiven { get; set; }
 		public List<string> CalledByAfterGiven { get; set; }
+		public List<string> CalledByAfterSpec { get; set; }
 		public List<string> CalledByAfterTest { get; set; }
+		public List<string> CalledByBeforeTest { get; set; }
 		public List<string> CalledByApplyAfterClassUnderTestInitialized { get; set; }
 		public List<string> CalledBySpecInit { get; set; }
 
@@ -16,7 +18,9 @@ namespace SpecsFor.StructureMap.Tests.ComposingContext.TestDomain
 			CalledByApplyAfterClassUnderTestInitialized = new List<string>();
 			CalledByDuringGiven = new List<string>();
 			CalledByAfterGiven = new List<string>();
+			CalledByAfterSpec = new List<string>();
 			CalledByAfterTest = new List<string>();
+			CalledByBeforeTest = new List<string>();
 		}
 	}
 }

--- a/SpecsFor.StructureMap.Tests/SpecsForEngineSpecs.cs
+++ b/SpecsFor.StructureMap.Tests/SpecsForEngineSpecs.cs
@@ -9,358 +9,389 @@ using StructureMap;
 
 namespace SpecsFor.StructureMap.Tests
 {
-	internal class SpecsForEngineSpecs
-	{
+    internal class SpecsForEngineSpecs
+    {
 		internal abstract class given_there_are_specs_for_config_classes_that_do_not_have_the_required_attributes : SpecsFor<SpecsForEngine<object>>
-		{
-			protected override void Given()
-			{
-				GetMockFor<ISpecValidator>()
-					.Setup(v => v.ValidateSpec(It.IsAny<ISpecs>()))
-					.Throws(new InvalidOperationException());
-			}
+        {
+            protected override void Given()
+            {
+                GetMockFor<ISpecValidator>()
+                    .Setup(v => v.ValidateSpec(It.IsAny<ISpecs>()))
+                    .Throws(new InvalidOperationException());
+            }
 
 			public class when_initializing_the_engine : given_there_are_specs_for_config_classes_that_do_not_have_the_required_attributes
-			{
-				private InvalidOperationException _exception;
+            {
+                private InvalidOperationException _exception;
 
-				protected override void When()
-				{
-					_exception = Assert.Throws<InvalidOperationException>(() => SUT.Init());
-				}
+                protected override void When()
+                {
+                    _exception = Assert.Throws<InvalidOperationException>(() => SUT.Init());
+                }
 
-				[Test]
-				public void then_it_throws_an_exception()
-				{
-					_exception.ShouldNotBeNull();
-				}
-			}
-		}
+                [Test]
+                public void then_it_throws_an_exception()
+                {
+                    _exception.ShouldNotBeNull();
+                }
+            }
+        }
 
-		internal class when_initializing_the_engine : SpecsFor<SpecsForEngine<object>>
-		{
-		    protected override void Given()
-		    {
-		        var mocker = GetMockFor<IAutoMocker>();
+        internal class when_initializing_the_engine : SpecsFor<SpecsForEngine<object>>
+        {
+            protected override void Given()
+            {
+                var mocker = GetMockFor<IAutoMocker>();
 
-		        mocker.Setup(x => x.CreateSUT<object>()).Returns(new object());
+                mocker.Setup(x => x.CreateSUT<object>()).Returns(new object());
 
-		        GetMockFor<ISpecs<object>>().Setup(x => x.CreateAutoMocker()).Returns(mocker.Object);
-		    }
+                GetMockFor<ISpecs<object>>().Setup(x => x.CreateAutoMocker()).Returns(mocker.Object);
+            }
 
             protected override void When()
-			{
-				SUT.Init();
-			}
+            {
+                SUT.Init();
+            }
 
-			[Test]
-			public void then_it_applies_spec_init_behaviors()
-			{
-				GetMockFor<IBehaviorStack>()
-					.Verify(s => s.ApplySpecInitTo(It.IsAny<ISpecs>()));
-			}
+            [Test]
+            public void then_it_applies_spec_init_behaviors()
+            {
+                GetMockFor<IBehaviorStack>()
+                    .Verify(s => s.ApplySpecInitTo(It.IsAny<ISpecs>()));
+            }
 
-			[Test]
-			public void then_it_invokes_the_createautomocker_callback()
-			{
-				GetMockFor<ISpecs<object>>()
-					.Verify(s => s.CreateAutoMocker());
-			}
+            [Test]
+            public void then_it_invokes_the_createautomocker_callback()
+            {
+                GetMockFor<ISpecs<object>>()
+                    .Verify(s => s.CreateAutoMocker());
+            }
 
-			[Test]
-			public void then_it_invokes_the_initialize_class_under_test_callback()
-			{
-				GetMockFor<ISpecs<object>>()
-					.Verify(s => s.InitializeClassUnderTest());
-			}
+            [Test]
+            public void then_it_invokes_the_initialize_class_under_test_callback()
+            {
+                GetMockFor<ISpecs<object>>()
+                    .Verify(s => s.InitializeClassUnderTest());
+            }
 
-			[Test]
-			public void then_it_applies_after_class_under_test_initialized_behaviors()
-			{
-				GetMockFor<IBehaviorStack>()
-					.Verify(s => s.ApplyAfterClassUnderTestInitializedTo(It.IsAny<ISpecs>()));
-			}
-		}
+            [Test]
+            public void then_it_applies_after_class_under_test_initialized_behaviors()
+            {
+                GetMockFor<IBehaviorStack>()
+                    .Verify(s => s.ApplyAfterClassUnderTestInitializedTo(It.IsAny<ISpecs>()));
+            }
+        }
 
 		public class when_initializing_the_engine_and_an_error_is_throwing_during_initialize_class_under_test : SpecsFor<SpecsForEngine<object>>
-		{
-			private SpecInitException _exception;
+        {
+            private SpecInitException _exception;
 
-			protected override void Given()
-			{
-				GetMockFor<ISpecs<object>>()
-					.Setup(s => s.InitializeClassUnderTest())
-					.Throws(new Exception());
-			}
+            protected override void Given()
+            {
+                GetMockFor<ISpecs<object>>()
+                    .Setup(s => s.InitializeClassUnderTest())
+                    .Throws(new Exception());
+            }
 
-			protected override void When()
-			{
-				_exception = Assert.Throws<SpecInitException>(() => SUT.Init());
-			}
+            protected override void When()
+            {
+                _exception = Assert.Throws<SpecInitException>(() => SUT.Init());
+            }
 
-			[Test]
-			public void then_it_throws_an_exception()
-			{
-				_exception.ShouldNotBeNull();
-			}
+            [Test]
+            public void then_it_throws_an_exception()
+            {
+                _exception.ShouldNotBeNull();
+            }
 
-			[Test]
-			public void then_it_calls_the_after_spec_step_on_any_behaviors()
-			{
-				GetMockFor<IBehaviorStack>()
-					.Verify(s => s.ApplyAfterSpecTo(It.IsAny<ISpecs>()));
-			}
-		}
+            [Test]
+            public void then_it_calls_the_after_spec_step_on_any_behaviors()
+            {
+                GetMockFor<IBehaviorStack>()
+                    .Verify(s => s.ApplyAfterSpecTo(It.IsAny<ISpecs>()));
+            }
+        }
 
-		internal class when_initializing_the_class_under_test : given_an_initialization_behavior_is_defined
-		{
-			protected override void When()
-			{
-				SUT.Init();
-				SUT.InitializeClassUnderTest();
-			}
+        internal class when_initializing_the_class_under_test : given_an_initialization_behavior_is_defined
+        {
+            protected override void When()
+            {
+                SUT.Init();
+                SUT.InitializeClassUnderTest();
+            }
 
-			[Test]
-			public void then_it_creates_the_class_under_test()
-			{
-				SUT.SUT.ShouldNotBeNull();
-			}
-		}
+            [Test]
+            public void then_it_creates_the_class_under_test()
+            {
+                SUT.SUT.ShouldNotBeNull();
+            }
+        }
 
-		internal abstract class given_an_initialization_behavior_is_defined : SpecsFor<SpecsForEngine<object>>
-		{
-			private readonly object _expected = new object();
+        internal abstract class given_an_initialization_behavior_is_defined : SpecsFor<SpecsForEngine<object>>
+        {
+            private readonly object _expected = new object();
 
-		    protected override void Given()
-		    {
-		        var mocker = GetMockFor<IAutoMocker>();
+            protected override void Given()
+            {
+                var mocker = GetMockFor<IAutoMocker>();
 
-		        mocker.Setup(x => x.CreateSUT<object>()).Returns(new object());
+                mocker.Setup(x => x.CreateSUT<object>()).Returns(new object());
 
-		        GetMockFor<ISpecs<object>>().Setup(x => x.CreateAutoMocker()).Returns(mocker.Object);
+                GetMockFor<ISpecs<object>>().Setup(x => x.CreateAutoMocker()).Returns(mocker.Object);
 
                 GetMockFor<IBehaviorStack>()
-					.Setup(s => s.GetInitializationMethodFor(It.IsAny<ISpecs<object>>()))
-					.Returns(() => _expected);
-			}
+                    .Setup(s => s.GetInitializationMethodFor(It.IsAny<ISpecs<object>>()))
+                    .Returns(() => _expected);
+            }
 
-			internal class when_initializing_the_class_under_test : given_an_initialization_behavior_is_defined
-			{
-				protected override void When()
-				{
-					SUT.Init();
-					SUT.InitializeClassUnderTest();
-				}
+            internal class when_initializing_the_class_under_test : given_an_initialization_behavior_is_defined
+            {
+                protected override void When()
+                {
+                    SUT.Init();
+                    SUT.InitializeClassUnderTest();
+                }
 
-				[Test]
-				public void then_it_uses_the_object_from_the_init_behavior()
-				{
-					SUT.SUT.ShouldBeSameAs(_expected);
-				}
-			}
-		}
+                [Test]
+                public void then_it_uses_the_object_from_the_init_behavior()
+                {
+                    SUT.SUT.ShouldBeSameAs(_expected);
+                }
+            }
+        }
 
-		internal class when_running_the_given_step : SpecsFor<SpecsForEngine<object>>
-		{
-			protected override void When()
-			{
-				SUT.Given();
-			}
+        internal class when_running_the_given_step : SpecsFor<SpecsForEngine<object>>
+        {
+            protected override void When()
+            {
+                SUT.Given();
+            }
 
-			[Test]
-			public void then_it_invokes_the_given_of_the_spec()
-			{
-				GetMockFor<ISpecs<object>>()
-					.Verify(s => s.Given());
-			}
+            [Test]
+            public void then_it_invokes_the_given_of_the_spec()
+            {
+                GetMockFor<ISpecs<object>>()
+                    .Verify(s => s.Given());
+            }
 
-			[Test]
-			public void then_it_invokes_the_given_behaviors()
-			{
-				GetMockFor<IBehaviorStack>()
-					.Verify(s => s.ApplyGivenTo(It.IsAny<ISpecs<object>>()));
-			}
-		}
+            [Test]
+            public void then_it_invokes_the_given_behaviors()
+            {
+                GetMockFor<IBehaviorStack>()
+                    .Verify(s => s.ApplyGivenTo(It.IsAny<ISpecs<object>>()));
+            }
+        }
 
 		internal abstract class given_an_error_is_thrown_by_the_spec_during_the_given_callback : SpecsFor<SpecsForEngine<IDisposable>>
-		{
-			protected override void Given()
-			{
-				GetMockFor<ISpecs<IDisposable>>()
-					.Setup(s => s.Given())
-					.Throws(new Exception());
-			}
+        {
+            protected override void Given()
+            {
+                GetMockFor<ISpecs<IDisposable>>()
+                    .Setup(s => s.Given())
+                    .Throws(new Exception());
+            }
 
-			internal class when_running_the_given_step : given_an_error_is_thrown_by_the_spec_during_the_given_callback
-			{
-				private GivenSpecificationException _exception;
+            internal class when_running_the_given_step : given_an_error_is_thrown_by_the_spec_during_the_given_callback
+            {
+                private GivenSpecificationException _exception;
 
-				protected override void When()
-				{
-					SUT.SUT = GetMockFor<IDisposable>().Object;
-					_exception = Assert.Throws<GivenSpecificationException>(() => SUT.Given());
-				}
+                protected override void When()
+                {
+                    SUT.SUT = GetMockFor<IDisposable>().Object;
+                    _exception = Assert.Throws<GivenSpecificationException>(() => SUT.Given());
+                }
 
-				[Test]
-				public void then_it_rethrows_the_exception()
-				{
-					_exception.ShouldNotBeNull();
-				}
+                [Test]
+                public void then_it_rethrows_the_exception()
+                {
+                    _exception.ShouldNotBeNull();
+                }
 
-				[Test]
-				public void then_it_invokes_the_after_spec_callback()
-				{
-					GetMockFor<IBehaviorStack>()
-						.Verify(s => s.ApplyAfterSpecTo(It.IsAny<ISpecs<IDisposable>>()));
-				}
+                [Test]
+                public void then_it_invokes_the_after_spec_callback()
+                {
+                    GetMockFor<IBehaviorStack>()
+                        .Verify(s => s.ApplyAfterSpecTo(It.IsAny<ISpecs<IDisposable>>()));
+                }
 
-				[Test]
-				public void then_it_disposes_of_the_system_under_test()
-				{
-					GetMockFor<IDisposable>()
-						.Verify(d => d.Dispose());
-				}
-			}
+                [Test]
+                public void then_it_disposes_of_the_system_under_test()
+                {
+                    GetMockFor<IDisposable>()
+                        .Verify(d => d.Dispose());
+                }
+            }
 
 			internal class when_running_the_given_step_and_multiple_exceptions_are_thrown : given_an_error_is_thrown_by_the_spec_during_the_given_callback
-			{
-				private GivenSpecificationException _exception;
+            {
+                private GivenSpecificationException _exception;
 
-				protected override void Given()
-				{
-					GetMockFor<IBehaviorStack>()
-						.Setup(s => s.ApplyAfterSpecTo(It.IsAny<ISpecs<IDisposable>>()))
-						.Throws(new InvalidOperationException("Other exception."));
+                protected override void Given()
+                {
+                    GetMockFor<IBehaviorStack>()
+                        .Setup(s => s.ApplyAfterSpecTo(It.IsAny<ISpecs<IDisposable>>()))
+                        .Throws(new InvalidOperationException("Other exception."));
 
-					base.Given();
-				}
+                    base.Given();
+                }
 
-				protected override void When()
-				{
-					SUT.SUT = GetMockFor<IDisposable>().Object;
-					_exception = Assert.Throws<GivenSpecificationException>(() => SUT.Given());
-				}
+                protected override void When()
+                {
+                    SUT.SUT = GetMockFor<IDisposable>().Object;
+                    _exception = Assert.Throws<GivenSpecificationException>(() => SUT.Given());
+                }
 
-				[Test]
-				public void then_it_throws_an_aggregate_exception_containing_both_exceptions()
-				{
-					_exception.Message.ShouldStartWith("An error occurred during the spec 'Given' phase.");
-					_exception.Exceptions.Length.ShouldEqual(2);
-				}
-			}
-		}
+                [Test]
+                public void then_it_throws_an_aggregate_exception_containing_both_exceptions()
+                {
+                    _exception.Message.ShouldStartWith("An error occurred during the spec 'Given' phase.");
+                    _exception.Exceptions.Length.ShouldEqual(2);
+                }
+            }
+        }
 
-		internal class when_running_the_when_stage : SpecsFor<SpecsForEngine<object>>
-		{
-			protected override void When()
-			{
-				SUT.When();
-			}
+        internal class when_running_the_when_stage : SpecsFor<SpecsForEngine<object>>
+        {
+            protected override void When()
+            {
+                SUT.When();
+            }
 
-			[Test]
-			public void then_it_calls_the_when_callback_on_the_spec()
-			{
-				GetMockFor<ISpecs<object>>()
-					.Verify(s => s.When());
-			}
-		}
+            [Test]
+            public void then_it_calls_the_when_callback_on_the_spec()
+            {
+                GetMockFor<ISpecs<object>>()
+                    .Verify(s => s.When());
+            }
+        }
 
-		internal abstract class given_an_error_is_thrown_by_the_spec_during_the_when_callback : SpecsFor<SpecsForEngine<IDisposable>>
-		{
-			protected override void Given()
-			{
-				GetMockFor<ISpecs<IDisposable>>()
-					.Setup(s => s.When())
-					.Throws(new Exception());
-			}
+        internal abstract class
+            given_an_error_is_thrown_by_the_spec_during_the_when_callback : SpecsFor<SpecsForEngine<IDisposable>>
+        {
+            protected override void Given()
+            {
+                GetMockFor<ISpecs<IDisposable>>()
+                    .Setup(s => s.When())
+                    .Throws(new Exception());
+            }
 
-			internal class when_running_the_when_stage : given_an_error_is_thrown_by_the_spec_during_the_when_callback
-			{
-				private WhenSpecificationException _exception;
+            internal class when_running_the_when_stage : given_an_error_is_thrown_by_the_spec_during_the_when_callback
+            {
+                private WhenSpecificationException _exception;
 
-				protected override void When()
-				{
-					SUT.SUT = GetMockFor<IDisposable>().Object;
-					_exception = Assert.Throws<WhenSpecificationException>(() => SUT.When());
-				}
+                protected override void When()
+                {
+                    SUT.SUT = GetMockFor<IDisposable>().Object;
+                    _exception = Assert.Throws<WhenSpecificationException>(() => SUT.When());
+                }
 
-				[Test]
-				public void then_it_rethrows_the_exception()
-				{
-					_exception.ShouldNotBeNull();
-				}
+                [Test]
+                public void then_it_rethrows_the_exception()
+                {
+                    _exception.ShouldNotBeNull();
+                }
 
-				[Test]
-				public void then_it_disposes_the_system_under_test()
-				{
-					GetMockFor<IDisposable>()
-						.Verify(d => d.Dispose());
-				}
+                [Test]
+                public void then_it_disposes_the_system_under_test()
+                {
+                    GetMockFor<IDisposable>()
+                        .Verify(d => d.Dispose());
+                }
 
-				[Test]
-				public void then_it_invokes_the_after_spec_callback_on_the_behaviors()
-				{
-					GetMockFor<IBehaviorStack>()
-						.Verify(s => s.ApplyAfterSpecTo(It.IsAny<ISpecs<IDisposable>>()));
-				}
-			}
+                [Test]
+                public void then_it_invokes_the_after_spec_callback_on_the_behaviors()
+                {
+                    GetMockFor<IBehaviorStack>()
+                        .Verify(s => s.ApplyAfterSpecTo(It.IsAny<ISpecs<IDisposable>>()));
+                }
+            }
 
-			internal class when_running_the_when_stage_and_an_error_is_thrown_by_a_behaviors_after_spec : given_an_error_is_thrown_by_the_spec_during_the_when_callback
-			{
-				private WhenSpecificationException _exception;
+            internal class
+                when_running_the_when_stage_and_an_error_is_thrown_by_a_behaviors_after_spec :
+                given_an_error_is_thrown_by_the_spec_during_the_when_callback
+            {
+                private WhenSpecificationException _exception;
 
-				protected override void Given()
-				{
-					GetMockFor<IBehaviorStack>()
-						.Setup(s => s.ApplyAfterSpecTo(It.IsAny<ISpecs<IDisposable>>()))
-						.Throws(new InvalidOperationException());
+                protected override void Given()
+                {
+                    GetMockFor<IBehaviorStack>()
+                        .Setup(s => s.ApplyAfterSpecTo(It.IsAny<ISpecs<IDisposable>>()))
+                        .Throws(new InvalidOperationException());
 
-					base.Given();
-				}
+                    base.Given();
+                }
 
-				protected override void When()
-				{
-					SUT.SUT = GetMockFor<IDisposable>().Object;
-					_exception = Assert.Throws<WhenSpecificationException>(() => SUT.When());
-				}
+                protected override void When()
+                {
+                    SUT.SUT = GetMockFor<IDisposable>().Object;
+                    _exception = Assert.Throws<WhenSpecificationException>(() => SUT.When());
+                }
 
-				[Test]
-				public void then_it_throws_an_aggregate_exception_containing_both_exceptions()
-				{
-					_exception.Message.StartsWith("An error occurred during the spec 'When' phase.");
-					_exception.Exceptions.Length.ShouldEqual(2);
-				}
-			}
-		}
+                [Test]
+                public void then_it_throws_an_aggregate_exception_containing_both_exceptions()
+                {
+                    _exception.Message.StartsWith("An error occurred during the spec 'When' phase.");
+                    _exception.Exceptions.Length.ShouldEqual(2);
+                }
+            }
+        }
 
-		internal class when_running_the_tear_down_stage : SpecsFor<SpecsForEngine<IDisposable>>
-		{
-			protected override void When()
-			{
-				SUT.SUT = GetMockFor<IDisposable>().Object;
-				SUT.TearDown();
-			}
+        internal class when_running_the_tear_down_stage : SpecsFor<SpecsForEngine<IDisposable>>
+        {
+            protected override void When()
+            {
+                SUT.SUT = GetMockFor<IDisposable>().Object;
+                SUT.TearDown();
+            }
 
-			[Test]
-			public void then_it_runs_the_after_spec_callback()
-			{
-				GetMockFor<ISpecs<IDisposable>>()
-					.Verify(s => s.AfterSpec());
-			}
+            [Test]
+            public void then_it_runs_the_after_spec_callback()
+            {
+                GetMockFor<ISpecs<IDisposable>>()
+                    .Verify(s => s.AfterSpec());
+            }
 
-			[Test]
-			public void then_it_runs_the_after_spec_behaviors()
-			{
-				GetMockFor<IBehaviorStack>()
-					.Verify(s => s.ApplyAfterSpecTo(It.IsAny<ISpecs<IDisposable>>()));
-			}
+            [Test]
+            public void then_it_runs_the_after_spec_behaviors()
+            {
+                GetMockFor<IBehaviorStack>()
+                    .Verify(s => s.ApplyAfterSpecTo(It.IsAny<ISpecs<IDisposable>>()));
+            }
 
-			[Test]
-			public void then_it_disposes_the_system_under_test()
-			{
-				GetMockFor<IDisposable>()
-					.Verify(d => d.Dispose());
-			}
-		}
-	}
+            [Test]
+            public void then_it_disposes_the_system_under_test()
+            {
+                GetMockFor<IDisposable>()
+                    .Verify(d => d.Dispose());
+            }
+        }
+
+        internal class when_running_the_after_test_stage : SpecsFor<SpecsForEngine<object>>
+        {
+            protected override void When()
+            {
+                SUT.AfterTest();
+            }
+
+            [Test]
+            public void then_it_runs_the_after_test_callback_on_the_behaviors()
+            {
+                GetMockFor<IBehaviorStack>().Verify(m => m.ApplyAfterTestTo(It.IsAny<ISpecs<object>>()));
+            }
+        }
+
+        internal class when_running_the_before_test_stage : SpecsFor<SpecsForEngine<object>>
+        {
+            protected override void When()
+            {
+                SUT.BeforeTest();
+            }
+
+            [Test]
+            public void then_it_runs_the_before_test_callback_on_the_behaviors()
+            {
+                GetMockFor<IBehaviorStack>().Verify(m => m.ApplyBeforeTestTo(It.IsAny<ISpecs<object>>()));
+            }
+        }
+    }
 }

--- a/SpecsFor.StructureMap.Tests/SpecsForSpecs.cs
+++ b/SpecsFor.StructureMap.Tests/SpecsForSpecs.cs
@@ -120,7 +120,7 @@ namespace SpecsFor.StructureMap.Tests
             }
 
             [Test]
-            public void then_it_uses_the_conrete_class()
+            public void then_it_uses_the_concrete_class()
             {
                 _result.ShouldEqual(6);
             }


### PR DESCRIPTION
This change is to bring the additional hooks of `BeforeTest` and `AfterTest` to Behaviors which currently only supports `AfterSpec`.